### PR TITLE
Add BridgeData V2 eval script and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ dmypy.json
 # Caches and Datasets
 cache/
 data/
+
+# Rollout videos and wandb logs
+rollouts/
+wandb/

--- a/README.md
+++ b/README.md
@@ -419,12 +419,68 @@ AttributeError: 'DLataset' object has no attribute 'traj_map'. Did you mean: 'fl
 
 ---
 
+## Evaluating OpenVLA
+
+### BridgeData V2 WidowX Evaluations
+
+#### Setup
+
+Clone the [BridgeData V2 WidowX controller repo](https://github.com/rail-berkeley/bridge_data_robot) and install the `widowx_envs` package:
+
+```bash
+git clone https://github.com/rail-berkeley/bridge_data_robot.git
+cd bridge_data_robot
+pip install -e widowx_envs
+```
+
+Additionally, install the [`edgeml`](https://github.com/youliangtan/edgeml) library:
+```bash
+git clone https://github.com/youliangtan/edgeml.git
+cd edgeml
+pip install -e .
+```
+
+Follow the instructions in the `bridge_data_robot` README to create the Bridge WidowX Docker container.
+
+#### Launching BridgeData V2 Evaluations
+
+There are multiple ways to run BridgeData V2 evaluations. We describe the server-client method below.
+
+In one Terminal window (e.g., in tmux), start the WidowX Docker container:
+
+```bash
+cd bridge_data_robot
+./generate_usb_config.sh
+USB_CONNECTOR_CHART=$(pwd)/usb_connector_chart.yml docker compose up --build robonet
+```
+
+In a second Terminal window, run the WidowX robot server:
+
+```bash
+cd bridge_data_robot
+docker compose exec robonet bash -lic "widowx_env_service --server"
+```
+
+In a third Terminal window, run the OpenVLA policy evaluation script:
+
+```bash
+cd openvla
+python experiments/robot/bridge/run_bridgev2_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b
+```
+
+If you run into any problems with evaluations, please file a GitHub Issue.
+
+---
+
 ## Repository Structure
 
 High-level overview of repository/project file-tree:
 
 + `prismatic` - Package source; provides core utilities for model loading, training, data preprocessing, etc.
 + `vla-scripts/` - Core scripts for training, fine-tuning, and deploying VLAs.
++ `experiments/` - Code for evaluating OpenVLA policies in robot environments.
 + `LICENSE` - All code is made available under the MIT License; happy hacking!
 + `Makefile` - Top-level Makefile (by default, supports linting - checking & auto-fix); extend as needed.
 + `pyproject.toml` - Full project configuration details (including dependencies), as well as tool configurations.

--- a/experiments/robot/bridge/bridgev2_utils.py
+++ b/experiments/robot/bridge/bridgev2_utils.py
@@ -1,0 +1,133 @@
+"""Utils for evaluating policies in real-world BridgeData V2 environments."""
+
+import os
+import sys
+import time
+
+import imageio
+import numpy as np
+import tensorflow as tf
+import torch
+from widowx_envs.widowx_env_service import WidowXClient, WidowXConfigs
+
+sys.path.append(".")
+from experiments.robot.bridge.widowx_env import WidowXGym
+
+# Initialize important constants and pretty-printing mode in NumPy.
+ACTION_DIM = 7
+BRIDGE_PROPRIO_DIM = 7
+DATE_TIME = time.strftime("%Y_%m_%d-%H_%M_%S")
+DEVICE = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+np.set_printoptions(formatter={"float": lambda x: "{0:0.2f}".format(x)})
+
+
+def get_widowx_env_params(cfg):
+    """Gets (mostly default) environment parameters for the WidowX environment."""
+    env_params = WidowXConfigs.DefaultEnvParams.copy()
+    env_params["override_workspace_boundaries"] = cfg.bounds
+    env_params["camera_topics"] = cfg.camera_topics
+    env_params["return_full_image"] = True
+    return env_params
+
+
+def get_widowx_env(cfg, model=None):
+    """Get WidowX control environment."""
+    # Set up the WidowX environment parameters
+    env_params = get_widowx_env_params(cfg)
+    start_state = np.concatenate([cfg.init_ee_pos, cfg.init_ee_quat])
+    env_params["start_state"] = list(start_state)
+    # Set up the WidowX client
+    widowx_client = WidowXClient(host=cfg.host_ip, port=cfg.port)
+    widowx_client.init(env_params)
+    env = WidowXGym(
+        widowx_client,
+        cfg=cfg,
+        blocking=cfg.blocking,
+    )
+    return env
+
+
+def get_next_task_label(task_label):
+    """Prompt the user to input the next task."""
+    if task_label == "":
+        user_input = ""
+        while user_input == "":
+            user_input = input("Enter the task name: ")
+        task_label = user_input
+    else:
+        user_input = input("Enter the task name (or leave blank to repeat the previous task): ")
+        if user_input == "":
+            pass  # Do nothing -> Let task_label be the same
+        else:
+            task_label = user_input
+    print(f"Task: {task_label}")
+    return task_label
+
+
+def save_rollout_video(rollout_images, idx):
+    """Saves an MP4 replay of an episode."""
+    os.makedirs("./rollouts", exist_ok=True)
+    mp4_path = f"./rollouts/rollout-{DATE_TIME}-{idx+1}.mp4"
+    video_writer = imageio.get_writer(mp4_path, fps=5)
+    for img in rollout_images:
+        video_writer.append_data(img)
+    video_writer.close()
+    print(f"Saved rollout MP4 at path {mp4_path}")
+
+
+def save_rollout_data(rollout_orig_images, rollout_images, rollout_states, rollout_actions, idx):
+    """
+    Saves rollout data from an episode.
+
+    Args:
+        rollout_orig_images (list): Original rollout images (before preprocessing).
+        rollout_images (list): Preprocessed images.
+        rollout_states (list): Proprioceptive states.
+        rollout_actions (list): Predicted actions.
+        idx (int): Episode index.
+    """
+    os.makedirs("./rollouts", exist_ok=True)
+    path = f"./rollouts/rollout-{DATE_TIME}-{idx+1}.npz"
+    # Convert lists to numpy arrays
+    orig_images_array = np.array(rollout_orig_images)
+    images_array = np.array(rollout_images)
+    states_array = np.array(rollout_states)
+    actions_array = np.array(rollout_actions)
+    # Save to a single .npz file
+    np.savez(path, orig_images=orig_images_array, images=images_array, states=states_array, actions=actions_array)
+    print(f"Saved rollout data at path {path}")
+
+
+def resize_image(img, resize_size):
+    """
+    Takes numpy array corresponding to a single image and returns resized image as numpy array.
+
+    NOTE (Moo Jin): To make input images in distribution with respect to the inputs seen at training time, we follow
+                    the same resizing scheme used in the Octo dataloader, which OpenVLA uses for training.
+    """
+    assert isinstance(resize_size, tuple)
+    # Resize to image size expected by model
+    img = tf.image.encode_jpeg(img)  # Encode as JPEG, as done in RLDS dataset builder
+    img = tf.io.decode_image(img, expand_animations=False, dtype=tf.uint8)  # Immediately decode back
+    img = tf.image.resize(img, resize_size, method="lanczos3", antialias=True)
+    img = tf.cast(tf.clip_by_value(tf.round(img), 0, 255), tf.uint8)
+    img = img.numpy()
+    return img
+
+
+def get_preprocessed_image(obs, resize_size):
+    """Extracts image from observations and preprocesses it."""
+    assert isinstance(resize_size, int) or isinstance(resize_size, tuple)
+    if isinstance(resize_size, int):
+        resize_size = (resize_size, resize_size)
+    obs["full_image"] = resize_image(obs["full_image"], resize_size)
+    return obs["full_image"]
+
+
+def refresh_obs(obs, env):
+    """Fetches new observations from the environment and updates the current observations."""
+    new_obs = env.get_observation()
+    obs["full_image"] = new_obs["full_image"]
+    obs["image_primary"] = new_obs["image_primary"]
+    obs["proprio"] = new_obs["proprio"]
+    return obs

--- a/experiments/robot/bridge/run_bridgev2_eval.py
+++ b/experiments/robot/bridge/run_bridgev2_eval.py
@@ -1,0 +1,183 @@
+"""
+run_bridge_eval.py
+
+Runs a model in a real-world Bridge V2 environment.
+
+Usage:
+    # OpenVLA:
+    python experiments/robot/bridge/run_bridge_eval.py --model_family openvla --pretrained_checkpoint openvla/openvla-7b
+"""
+
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Union
+
+import draccus
+
+# Append current directory so that interpreter can find experiments.robot
+sys.path.append(".")
+from experiments.robot.bridge.bridgev2_utils import (
+    get_next_task_label,
+    get_preprocessed_image,
+    get_widowx_env,
+    refresh_obs,
+    save_rollout_data,
+    save_rollout_video,
+)
+from experiments.robot.openvla_utils import get_processor
+from experiments.robot.robot_utils import (
+    get_action,
+    get_image_resize_size,
+    get_model,
+)
+
+
+@dataclass
+class GenerateConfig:
+    # fmt: off
+
+    #################################################################################################################
+    # Model-specific parameters
+    #################################################################################################################
+    model_family: str = "openvla"                               # Model family
+    pretrained_checkpoint: Union[str, Path] = ""                # Pretrained checkpoint path
+    load_in_8bit: bool = False                                  # (For OpenVLA only) Load with 8-bit quantization
+    load_in_4bit: bool = False                                  # (For OpenVLA only) Load with 4-bit quantization
+
+    center_crop: bool = False                                   # Center crop? (if trained w/ random crop image aug)
+
+    #################################################################################################################
+    # WidowX environment-specific parameters
+    #################################################################################################################
+    host_ip: str = "localhost"
+    port: int = 5556
+
+    # Note: Setting initial orientation with a 30 degree offset, which makes the robot appear more natural
+    init_ee_pos: List[float] = field(default_factory=lambda: [0.3, -0.09, 0.26])
+    init_ee_quat: List[float] = field(default_factory=lambda: [0, -0.259, 0, -0.966])
+    bounds: List[List[float]] = field(default_factory=lambda: [
+            [0.1, -0.20, -0.01, -1.57, 0],
+            [0.45, 0.25, 0.30, 1.57, 0],
+        ]
+    )
+
+    camera_topics: List[Dict[str, str]] = field(default_factory=lambda: [{"name": "/blue/image_raw"}])
+
+    blocking: bool = False                                      # Whether to use blocking control
+    max_episodes: int = 50                                      # Max number of episodes to run
+    max_steps: int = 60                                         # Max number of timesteps per episode
+    control_frequency: float = 5                                # WidowX control frequency
+
+    #################################################################################################################
+    # Utils
+    #################################################################################################################
+    save_data: bool = False                                     # Whether to save rollout data (images, actions, etc.)
+
+    # fmt: on
+
+
+@draccus.wrap()
+def eval_model_in_bridge_env(cfg: GenerateConfig) -> None:
+    assert cfg.pretrained_checkpoint is not None, "cfg.pretrained_checkpoint must not be None!"
+    assert not cfg.center_crop, "`center_crop` should be disabled for Bridge evaluations!"
+
+    # [OpenVLA] Set action un-normalization key
+    cfg.unnorm_key = "bridge_orig"
+
+    # Load model
+    model = get_model(cfg)
+
+    # [OpenVLA] Get Hugging Face processor
+    processor = None
+    if cfg.model_family == "openvla":
+        processor = get_processor(cfg)
+
+    # Initialize the WidowX environment
+    env = get_widowx_env(cfg, model)
+
+    # Get expected image dimensions
+    resize_size = get_image_resize_size(cfg)
+
+    # Start evaluation
+    task_label = ""
+    episode_idx = 0
+    while episode_idx < cfg.max_episodes:
+        # Get task description from user
+        task_label = get_next_task_label(task_label)
+
+        # Reset environment
+        obs, _ = env.reset()
+
+        # Setup
+        t = 0
+        step_duration = 1.0 / cfg.control_frequency
+        replay_images = []
+        if cfg.save_data:
+            rollout_images = []
+            rollout_states = []
+            rollout_actions = []
+
+        # Start episode
+        input(f"Press Enter to start episode {episode_idx+1}...")
+        print("Starting episode... Press Ctrl-C to terminate episode early!")
+        last_tstamp = time.time()
+        while t < cfg.max_steps:
+            try:
+                curr_tstamp = time.time()
+                if curr_tstamp > last_tstamp + step_duration:
+                    print(f"t: {t}")
+                    print(f"Previous step elapsed time (sec): {curr_tstamp - last_tstamp:.2f}")
+                    last_tstamp = time.time()
+
+                    # Refresh the camera image and proprioceptive state
+                    obs = refresh_obs(obs, env)
+
+                    # Save full (not preprocessed) image for replay video
+                    replay_images.append(obs["full_image"])
+
+                    # Get preprocessed image
+                    obs["full_image"] = get_preprocessed_image(obs, resize_size)
+
+                    # Query model to get action
+                    action = get_action(
+                        cfg,
+                        model,
+                        obs,
+                        task_label,
+                        processor=processor,
+                    )
+
+                    # [If saving rollout data] Save preprocessed image, robot state, and action
+                    if cfg.save_data:
+                        rollout_images.append(obs["full_image"])
+                        rollout_states.append(obs["proprio"])
+                        rollout_actions.append(action)
+
+                    # Execute action
+                    print("action:", action)
+                    obs, _, _, _, _ = env.step(action)
+                    t += 1
+
+            except (KeyboardInterrupt, Exception) as e:
+                if isinstance(e, KeyboardInterrupt):
+                    print("\nCaught KeyboardInterrupt: Terminating episode early.")
+                else:
+                    print(f"\nCaught exception: {e}")
+                break
+
+        # Save a replay video of the episode
+        save_rollout_video(replay_images, episode_idx)
+
+        # [If saving rollout data] Save rollout data
+        if cfg.save_data:
+            save_rollout_data(replay_images, rollout_images, rollout_states, rollout_actions, idx=episode_idx)
+
+        # Redo episode or continue
+        if input("Enter 'r' if you want to redo the episode, or press Enter to continue: ") != "r":
+            episode_idx += 1
+
+
+if __name__ == "__main__":
+    eval_model_in_bridge_env()

--- a/experiments/robot/bridge/widowx_env.py
+++ b/experiments/robot/bridge/widowx_env.py
@@ -1,0 +1,160 @@
+"""
+WidowXGym environment definition.
+
+Copied over from the Octo eval code linked below, with some modifications:
+https://github.com/octo-models/octo/blob/main/examples/envs/widowx_env.py
+"""
+
+import time
+from typing import Dict
+
+import gym
+import numpy as np
+from pyquaternion import Quaternion
+from widowx_envs.widowx_env_service import WidowXClient
+
+
+def state_to_eep(xyz_coor, zangle: float):
+    """
+    Implements the state to end-effector pose function, returning a 4x4 matrix.
+    Refer to `widowx_controller/widowx_controller.py` in the `bridge_data_robot` codebase.
+    """
+    assert len(xyz_coor) == 3
+    DEFAULT_ROTATION = np.array([[0, 0, 1.0], [0, 1.0, 0], [-1.0, 0, 0]])
+    new_pose = np.eye(4)
+    new_pose[:3, -1] = xyz_coor
+    new_quat = Quaternion(axis=np.array([0.0, 0.0, 1.0]), angle=zangle) * Quaternion(matrix=DEFAULT_ROTATION)
+    new_pose[:3, :3] = new_quat.rotation_matrix
+    return new_pose
+
+
+def wait_for_obs(widowx_client):
+    """Fetches an observation from the WidowXClient."""
+    obs = widowx_client.get_observation()
+    while obs is None:
+        print("Waiting for observations...")
+        obs = widowx_client.get_observation()
+        time.sleep(1)
+    return obs
+
+
+def convert_obs(obs, im_size):
+    """Preprocesses image and proprio observations."""
+    # Preprocess image
+    image_obs = (obs["image"].reshape(3, im_size, im_size).transpose(1, 2, 0) * 255).astype(np.uint8)
+    # Add padding to proprio to match RLDS training
+    proprio = np.concatenate([obs["state"][:6], [0], obs["state"][-1:]])
+    return {
+        "image_primary": image_obs,
+        "full_image": obs["full_image"],
+        "proprio": proprio,
+    }
+
+
+def null_obs(img_size):
+    """Returns a dummy observation with all-zero image and proprio."""
+    return {
+        "image_primary": np.zeros((img_size, img_size, 3), dtype=np.uint8),
+        "proprio": np.zeros((8,), dtype=np.float64),
+    }
+
+
+class WidowXGym(gym.Env):
+    """
+    A Gym environment for the WidowX controller provided by:
+    https://github.com/rail-berkeley/bridge_data_robot
+    """
+
+    def __init__(
+        self,
+        widowx_client: WidowXClient,
+        cfg: Dict,
+        im_size: int = 256,
+        blocking: bool = True,
+    ):
+        self.widowx_client = widowx_client
+        self.im_size = im_size
+        self.blocking = blocking
+        self.observation_space = gym.spaces.Dict(
+            {
+                "image_primary": gym.spaces.Box(
+                    low=np.zeros((im_size, im_size, 3)),
+                    high=255 * np.ones((im_size, im_size, 3)),
+                    dtype=np.uint8,
+                ),
+                "full_image": gym.spaces.Box(
+                    low=np.zeros((480, 640, 3)),
+                    high=255 * np.ones((480, 640, 3)),
+                    dtype=np.uint8,
+                ),
+                "proprio": gym.spaces.Box(low=np.ones((8,)) * -1, high=np.ones((8,)), dtype=np.float64),
+            }
+        )
+        self.action_space = gym.spaces.Box(low=np.zeros((7,)), high=np.ones((7,)), dtype=np.float64)
+        self.cfg = cfg
+
+    def step(self, action):
+        self.widowx_client.step_action(action, blocking=self.blocking)
+
+        raw_obs = self.widowx_client.get_observation()
+
+        truncated = False
+        if raw_obs is None:
+            # this indicates a loss of connection with the server
+            # due to an exception in the last step so end the trajectory
+            truncated = True
+            obs = null_obs(self.im_size)  # obs with all zeros
+        else:
+            obs = convert_obs(raw_obs, self.im_size)
+
+        return obs, 0, False, truncated, {}
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+
+        self.widowx_client.reset()
+        self.move_to_start_state()
+
+        raw_obs = wait_for_obs(self.widowx_client)
+        obs = convert_obs(raw_obs, self.im_size)
+
+        return obs, {}
+
+    def get_observation(self):
+        raw_obs = wait_for_obs(self.widowx_client)
+        obs = convert_obs(raw_obs, self.im_size)
+        return obs
+
+    def move_to_start_state(self):
+        successful = False
+        while not successful:
+            try:
+                # Get XYZ position from user.
+                init_x, init_y, init_z = self.cfg.init_ee_pos
+                x_val = input(f"Enter x value of gripper starting position (leave empty for default == {init_x}): ")
+                if x_val == "":
+                    x_val = init_x
+                y_val = input(f"Enter y value of gripper starting position (leave empty for default == {init_y}): ")
+                if y_val == "":
+                    y_val = init_y
+                z_val = input(f"Enter z value of gripper starting position (leave empty for default == {init_z}): ")
+                if z_val == "":
+                    z_val = init_z
+                # Fix initial orientation and add user's commanded XYZ into start transform.
+                # Initial orientation: gripper points ~15 degrees away from the standard orientation (quat=[0, 0, 0, 1]).
+                transform = np.array(
+                    [
+                        [0.267, 0.000, 0.963, float(x_val)],
+                        [0.000, 1.000, 0.000, float(y_val)],
+                        [-0.963, 0.000, 0.267, float(z_val)],
+                        [0.00, 0.00, 0.00, 1.00],
+                    ]
+                )
+                # IMPORTANT: It is very important to move to reset position with blocking==True.
+                #            Otherwise, the controller's `_reset_previous_qpos()` call will be called immediately after
+                #            the move command is given -- and before the move is complete -- and the initial state will
+                #            be totally incorrect.
+                self.widowx_client.move(transform, duration=0.8, blocking=True)
+                successful = True
+            except Exception as e:
+                print(e)

--- a/experiments/robot/openvla_utils.py
+++ b/experiments/robot/openvla_utils.py
@@ -1,0 +1,170 @@
+"""Utils for evaluating the OpenVLA policy."""
+
+import json
+import os
+import time
+
+import numpy as np
+import tensorflow as tf
+import torch
+from PIL import Image
+from transformers import AutoConfig, AutoImageProcessor, AutoModelForVision2Seq, AutoProcessor
+
+from prismatic.extern.hf.configuration_prismatic import OpenVLAConfig
+from prismatic.extern.hf.modeling_prismatic import OpenVLAForActionPrediction
+from prismatic.extern.hf.processing_prismatic import PrismaticImageProcessor, PrismaticProcessor
+
+# Initialize important constants and pretty-printing mode in NumPy.
+ACTION_DIM = 7
+DATE = time.strftime("%Y_%m_%d")
+DATE_TIME = time.strftime("%Y_%m_%d-%H_%M_%S")
+DEVICE = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+np.set_printoptions(formatter={"float": lambda x: "{0:0.3f}".format(x)})
+
+# Initialize system prompt for OpenVLA v0.1.
+OPENVLA_V01_SYSTEM_PROMPT = (
+    "A chat between a curious user and an artificial intelligence assistant. "
+    "The assistant gives helpful, detailed, and polite answers to the user's questions."
+)
+
+
+def get_vla(cfg):
+    """Loads and returns a VLA model from checkpoint."""
+    # Load VLA checkpoint.
+    print("[*] Instantiating Pretrained VLA model")
+    print("[*] Loading in BF16 with Flash-Attention Enabled")
+
+    # Register OpenVLA model to HF Auto Classes (not needed if the model is on HF Hub)
+    AutoConfig.register("openvla", OpenVLAConfig)
+    AutoImageProcessor.register(OpenVLAConfig, PrismaticImageProcessor)
+    AutoProcessor.register(OpenVLAConfig, PrismaticProcessor)
+    AutoModelForVision2Seq.register(OpenVLAConfig, OpenVLAForActionPrediction)
+
+    vla = AutoModelForVision2Seq.from_pretrained(
+        cfg.pretrained_checkpoint,
+        attn_implementation="flash_attention_2",
+        torch_dtype=torch.bfloat16,
+        load_in_8bit=cfg.load_in_8bit,
+        load_in_4bit=cfg.load_in_4bit,
+        low_cpu_mem_usage=True,
+        trust_remote_code=True,
+    )
+
+    # Move model to device.
+    # Note: `.to()` is not supported for 8-bit or 4-bit bitsandbytes models, but the model will
+    #       already be set to the right devices and casted to the correct dtype upon loading.
+    if not cfg.load_in_8bit and not cfg.load_in_4bit:
+        vla = vla.to(DEVICE)
+
+    # Load dataset stats used during finetuning (for action un-normalization).
+    dataset_statistics_path = os.path.join(cfg.pretrained_checkpoint, "dataset_statistics.json")
+    if os.path.isfile(dataset_statistics_path):
+        with open(dataset_statistics_path, "r") as f:
+            norm_stats = json.load(f)
+        vla.norm_stats = norm_stats
+    else:
+        print(
+            "WARNING: No local dataset_statistics.json file found for current checkpoint.\n"
+            "You can ignore this if you are loading the base VLA (i.e. not fine-tuned) checkpoint."
+            "Otherwise, you may run into errors when trying to call `predict_action()` due to an absent `unnorm_key`."
+        )
+
+    return vla
+
+
+def get_processor(cfg):
+    """Get VLA model's Hugging Face processor."""
+    processor = AutoProcessor.from_pretrained(cfg.pretrained_checkpoint, trust_remote_code=True)
+    return processor
+
+
+def crop_and_resize(image, crop_scale, batch_size):
+    """
+    Center-crops an image to have area `crop_scale` * (original image area), and then resizes back
+    to original size. We use the same logic seen in the `dlimp` RLDS datasets wrapper to avoid
+    distribution shift at test time.
+
+    Args:
+        image: TF Tensor of shape (batch_size, H, W, C) or (H, W, C) and datatype tf.float32 with
+               values between [0,1].
+        crop_scale: The area of the center crop with respect to the original image.
+        batch_size: Batch size.
+    """
+    # Convert from 3D Tensor (H, W, C) to 4D Tensor (batch_size, H, W, C)
+    assert image.shape.ndims == 3 or image.shape.ndims == 4
+    expanded_dims = False
+    if image.shape.ndims == 3:
+        image = tf.expand_dims(image, axis=0)
+        expanded_dims = True
+
+    # Get height and width of crop
+    new_heights = tf.reshape(tf.clip_by_value(tf.sqrt(crop_scale), 0, 1), shape=(batch_size,))
+    new_widths = tf.reshape(tf.clip_by_value(tf.sqrt(crop_scale), 0, 1), shape=(batch_size,))
+
+    # Get bounding box representing crop
+    height_offsets = (1 - new_heights) / 2
+    width_offsets = (1 - new_widths) / 2
+    bounding_boxes = tf.stack(
+        [
+            height_offsets,
+            width_offsets,
+            height_offsets + new_heights,
+            width_offsets + new_widths,
+        ],
+        axis=1,
+    )
+
+    # Crop and then resize back up
+    image = tf.image.crop_and_resize(image, bounding_boxes, tf.range(batch_size), (224, 224))
+
+    # Convert back to 3D Tensor (H, W, C)
+    if expanded_dims:
+        image = image[0]
+
+    return image
+
+
+def get_vla_action(vla, processor, base_vla_name, obs, task_label, unnorm_key, center_crop=False):
+    """Generates an action with the VLA policy."""
+    image = Image.fromarray(obs["full_image"])
+    image = image.convert("RGB")
+
+    # (If trained with image augmentations) Center crop image and then resize back up to original size.
+    # IMPORTANT: Let's say crop scale == 0.9. To get the new height and width (post-crop), multiply
+    #            the original height and width by sqrt(0.9) -- not 0.9!
+    if center_crop:
+        batch_size = 1
+        crop_scale = 0.9
+
+        # Convert to TF Tensor and record original data type (should be tf.uint8)
+        image = tf.convert_to_tensor(np.array(image))
+        orig_dtype = image.dtype
+
+        # Convert to data type tf.float32 and values between [0,1]
+        image = tf.image.convert_image_dtype(image, tf.float32)
+
+        # Crop and then resize back to original size
+        image = crop_and_resize(image, crop_scale, batch_size)
+
+        # Convert back to original data type
+        image = tf.clip_by_value(image, 0, 1)
+        image = tf.image.convert_image_dtype(image, orig_dtype, saturate=True)
+
+        # Convert back to PIL Image
+        image = Image.fromarray(image.numpy())
+        image = image.convert("RGB")
+
+    # Build VLA prompt
+    if "openvla-v01" in base_vla_name:  # OpenVLA v0.1
+        prompt = (
+            f"{OPENVLA_V01_SYSTEM_PROMPT} USER: What action should the robot take to {task_label.lower()}? ASSISTANT:"
+        )
+    else:  # OpenVLA
+        prompt = f"In: What action should the robot take to {task_label.lower()}?\nOut:"
+
+    # Process inputs.
+    inputs = processor(prompt, image).to(DEVICE, dtype=torch.bfloat16)
+
+    # Get action.
+    action = vla.predict_action(**inputs, unnorm_key=unnorm_key, do_sample=False)
+    return action

--- a/experiments/robot/robot_utils.py
+++ b/experiments/robot/robot_utils.py
@@ -1,0 +1,79 @@
+"""Utils for evaluating robot policies in various environments."""
+
+import time
+
+import numpy as np
+import torch
+
+from experiments.robot.openvla_utils import (
+    get_vla,
+    get_vla_action,
+)
+
+# Initialize important constants and pretty-printing mode in NumPy.
+ACTION_DIM = 7
+DATE = time.strftime("%Y_%m_%d")
+DATE_TIME = time.strftime("%Y_%m_%d-%H_%M_%S")
+DEVICE = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+np.set_printoptions(formatter={"float": lambda x: "{0:0.3f}".format(x)})
+
+# Initialize system prompt for OpenVLA v0.1.
+OPENVLA_V01_SYSTEM_PROMPT = (
+    "A chat between a curious user and an artificial intelligence assistant. "
+    "The assistant gives helpful, detailed, and polite answers to the user's questions."
+)
+
+
+def get_model(cfg, wrap_diffusion_policy_for_droid=False):
+    """Load model for evaluation."""
+    if cfg.model_family == "openvla":
+        model = get_vla(cfg)
+    else:
+        raise ValueError("Unexpected `model_family` found in config.")
+    print(f"Loaded model: {type(model)}")
+    return model
+
+
+def get_image_resize_size(cfg):
+    """
+    Gets image resize size for a model class.
+    If `resize_size` is an int, then the resized image will be a square.
+    Else, the image will be a rectangle.
+    """
+    if cfg.model_family == "openvla":
+        resize_size = 224
+    else:
+        raise ValueError("Unexpected `model_family` found in config.")
+    return resize_size
+
+
+def get_action(cfg, model, obs, task_label, processor=None):
+    """Queries the model to get an action."""
+    if cfg.model_family == "openvla":
+        action = get_vla_action(
+            model, processor, cfg.pretrained_checkpoint, obs, task_label, cfg.unnorm_key, center_crop=cfg.center_crop
+        )
+        assert action.shape == (ACTION_DIM,)
+    else:
+        raise ValueError("Unexpected `model_family` found in config.")
+    return action
+
+
+def normalize_gripper_action(action, binarize=True):
+    """
+    Changes gripper action (last dimension of action vector) from [0,1] to [-1,+1].
+    Necessary for some environments (not Bridge) because the dataset wrapper standardizes gripper actions to [0,1].
+    Note that unlike the other action dimensions, the gripper action is not normalized to [-1,+1] by default by
+    the dataset wrapper.
+
+    Normalization formula: y = 2 * (x - orig_low) / (orig_high - orig_low) - 1
+    """
+    # Just normalize the last action to [-1,+1].
+    orig_low, orig_high = 0.0, 1.0
+    action[..., -1] = 2 * (action[..., -1] - orig_low) / (orig_high - orig_low) - 1
+
+    if binarize:
+        # Binarize to -1 or +1.
+        action[..., -1] = np.sign(action[..., -1])
+
+    return action


### PR DESCRIPTION
This PR adds code for running OpenVLA in real-world BridgeData V2 WidowX robot environments. 

We add the following files:

- `experiments/robot/bridge/run_bridgev2_eval.py`: Main script for running BridgeData V2 evaluations
- `experiments/robot/bridge/bridgev2_utils.py`: Utils for BridgeData V2 environments specifically
- `experiments/robot/bridge/widowx_env.py`: WidowX robot environment code
- `experiments/robot/openvla_utils.py`: Utils for evaluating the OpenVLA policy specifically
- `experiments/robot/robot_utils.py`: General utils for evaluating robot policies in various environments

Instructions for setting up and launching Bridge evaluations can be found in the updated README.