### PR TITLE
Save New Dataset Normalization Statistics in HF Config

### DIFF
--- a/prismatic/extern/hf/modeling_prismatic.py
+++ b/prismatic/extern/hf/modeling_prismatic.py
@@ -564,3 +564,15 @@ class OpenVLAForActionPrediction(PrismaticForConditionalGeneration):
         """Get all the logged statistics for the given dataset."""
         unnorm_key = self._check_unnorm_key(self.norm_stats, unnorm_key)
         return self.norm_stats[unnorm_key]["action"]
+
+    def update_normalization_stats(self, new_norm_stats: Dict, overwrite: bool = False) -> None:
+        """Update the normalization statistics in `self.config` with new dataset stats, overwriting if necessary."""
+        keys_to_overwrite = self.config.norm_stats.keys() & new_norm_stats.keys()
+        if (not overwrite) and len(keys_to_overwrite) > 0:
+            raise ValueError(
+                f"New normalization statistics contains pre-existing keys: `{keys_to_overwrite}`; "
+                f"Pass `overwrite=True` to override (but be careful)!"
+            )
+
+        # Update `self.config.norm_stats`
+        self.config.update(new_norm_stats)


### PR DESCRIPTION
When finetuning OpenVLA models through the HF AutoModel interface, we save `dataset_statistics.json` to a separate directory, introducing extra confusion / possible source of error when deploying models for inference.

Instead, we now explicitly update the underlying HF config object with new dataset statistics (with an option to overwrite existing dataset normalization stats), which automatically get saved/loaded when calling `save_pretrained/from_pretrained`.