### PR TITLE
Finetuning with custom expert demos

### DIFF
--- a/prismatic/vla/datasets/rlds/oxe/configs.py
+++ b/prismatic/vla/datasets/rlds/oxe/configs.py
@@ -641,4 +641,12 @@ OXE_DATASET_CONFIGS = {
         "state_encoding": StateEncoding.POS_EULER,
         "action_encoding": ActionEncoding.EEF_POS,
     },
+    # Finetuning with Custom expert demos
+    "expert_demos": {
+        "image_obs_keys": {"primary": "image_primary", "secondary": None, "wrist": None},
+        "depth_obs_keys": {"primary": None, "secondary": None, "wrist": None},
+        "state_obs_keys": ["EEF_state", None, "gripper_state"],
+        "state_encoding": StateEncoding.POS_EULER,
+        "action_encoding": ActionEncoding.EEF_POS,
+    },
 }

--- a/prismatic/vla/datasets/rlds/oxe/transforms.py
+++ b/prismatic/vla/datasets/rlds/oxe/transforms.py
@@ -824,6 +824,26 @@ def tdroid_dataset_transform(trajectory: Dict[str, Any]) -> Dict[str, Any]:
     return trajectory
 
 
+def expert_demos_oxe_dataset_transform(trajectory: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Sample transform for SERL demos in Open X-Embodiment mixture.
+    """
+    trajectory["action"] = tf.concat(
+        [
+            trajectory["action"][:, :6],
+            binarize_gripper_actions(trajectory["action"][:, -1])[:, None],
+        ],
+        axis=1,
+    )
+    size = tf.shape(trajectory["observation"]["state"])[0]
+    # trajectory["language_instruction"] = tf.constant("Pick up the orange blob", dtype=tf.string)
+    # trajectory["language_instruction"] = tf.fill((size,), "Pick up the orange blob", dtype=tf.string)
+    trajectory["language_instruction"] = trajectory["language_text"]
+    trajectory["observation"]["EEF_state"] = trajectory["observation"]["state"][:, :6]
+    trajectory["observation"]["gripper_state"] = trajectory["observation"]["state"][:, -1:]
+    return trajectory
+
+
 # === Registry ===
 OXE_STANDARDIZATION_TRANSFORMS = {
     "bridge_oxe": bridge_oxe_dataset_transform,
@@ -897,4 +917,6 @@ OXE_STANDARDIZATION_TRANSFORMS = {
     "tdroid_cover_object_with_towel": tdroid_dataset_transform,
     ### DROID Finetuning datasets
     "droid_wipe": droid_finetuning_transform,
+    ### Custom Finetuning datasets
+    "expert_demos": expert_demos_oxe_dataset_transform,
 }

--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -183,6 +183,7 @@ def finetune(cfg: FinetuneConfig) -> None:
 
     # Wrap VLA in PyTorch DDP Wrapper for Multi-GPU Training
     vla = DDP(vla, device_ids=[device_id], find_unused_parameters=True, gradient_as_bucket_view=True)
+    vla._set_static_graph()   # <---- ADD THIS LINE
 
     # Create Optimizer =>> note that we default to a simple constant learning rate!
     trainable_params = [param for param in vla.parameters() if param.requires_grad]


### PR DESCRIPTION
This serves as an example to finetune with custom dataset:

- Use: [manipulator_gym](https://github.com/rail-berkeley/manipulator_gym?tab=readme-ov-file#finetuning-pipeline)
   - easy way to quickly collect `expert_demos` dataset, and finetune it with LoRa
   - Finetuning instructions are also documented

- The error https://github.com/openvla/openvla/issues/25 still exists. added:
```py
vla._set_static_graph()   # <---- ADD THIS LINE
```
