### PR TITLE
Fix model checkpointing  in finetune.py

### DIFF
--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -318,7 +318,7 @@ def finetune(cfg: FinetuneConfig) -> None:
                 progress.update()
 
             # Save Model Checkpoint =>> by default, only keeps the latest checkpoint, continually overwriting it!
-            if gradient_step_idx > 0 and gradient_step_idx % cfg.save_steps == 0:
+            if gradient_step_idx > 0 and gradient_step_idx % cfg.save_steps == 0 and batch_idx % cfg.grad_accumulation_steps == 0:
                 if distributed_state.is_main_process:
                     print(f"Saving Model Checkpoint for Step {gradient_step_idx}")
 

--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -318,7 +318,7 @@ def finetune(cfg: FinetuneConfig) -> None:
                 progress.update()
 
             # Save Model Checkpoint =>> by default, only keeps the latest checkpoint, continually overwriting it!
-            if gradient_step_idx > 0 and gradient_step_idx % cfg.save_steps == 0 and batch_idx % cfg.grad_accumulation_steps == 0:
+            if gradient_step_idx > 0 and gradient_step_idx % cfg.save_steps == 0 and (batch_idx + 1) % cfg.grad_accumulation_steps == 0:
                 if distributed_state.is_main_process:
                     print(f"Saving Model Checkpoint for Step {gradient_step_idx}")
 


### PR DESCRIPTION
The model checkpoints are created based on `gradient_step_idx`. However, if `grad_accumulation_steps > 1`, `gradient_step_idx` is not incremented until `grad_accumulation_steps` batches are collected. This was resulting in unnecessary model checkpointing.

The extra criterion makes sure the model is only saved once when `gradient_step_idx % cfg.save_steps == 0`.