### PR TITLE
"Fix: prevent double-counting image patch length in batching logic"

### DIFF
--- a/prismatic/util/batching_utils.py
+++ b/prismatic/util/batching_utils.py
@@ -170,7 +170,7 @@ class SplitModalitySampler(Sampler):
         all_batches = [merged_batches[idx] for idx in merge_idxs]
 
         # [Quality of Life] Shift "max length" batch to index 0 --> if we OOM, it happens immediately!
-        all_lengths = [length + ((_n_patches := 24 * 24) if is_mm else 0) for is_mm, length in self.modality_lengths]
+        all_lengths = [length for is_mm, length in self.modality_lengths]
         all_batches_max_lengths = []
         for batch in all_batches:
             all_batches_max_lengths.append(max([all_lengths[idx] for idx in batch]))


### PR DESCRIPTION
In get_modality_lengths(): 
length = n_image_patches + n_words if is_multimodal. 
Since patches have been added, we want to avoid double counting for this line: 
all_lengths = [length + ((_n_patches := 24 * 24) if is_mm else 0) for is_mm, length in self.modality_lengths]