### PR TITLE
Add LIBERO reproduction workflow and simulation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,11 @@ data/
 # Rollout videos and wandb logs
 rollouts/
 wandb/
+
+# local eval artifacts
+experiments/logs/
+rollouts/
+
+# local eval artifacts
+experiments/logs/
+rollouts/

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ export HF_HUB_DISABLE_XET=1
 export HF_HUB_ENABLE_HF_TRANSFER=0
 ```
 
-如果你走代理，另外加上：
+如果走代理，另外加上：
 
 ```bash
 export HTTP_PROXY=http://127.0.0.1:7897
@@ -201,7 +201,6 @@ export http_proxy=$HTTP_PROXY
 export https_proxy=$HTTPS_PROXY
 ```
 
-> 作用说明：  
 > - `HF_HUB_ENABLE_HF_TRANSFER=0`：下载失败时错误信息更清晰，且常比 hf_transfer 稳。  
 > - `HF_HUB_DISABLE_XET=1`：避免部分网络环境对 xet/cas 链路不稳定。
 
@@ -304,7 +303,7 @@ $OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
 
 ---
 
-## 8. 推理过程中每一步在做什么（机制解释）
+## 8. 推理过程中每一步在做什么
 
 下面对应 `experiments/robot/libero/run_libero_eval.py` 的主流程：
 
@@ -340,14 +339,14 @@ $OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
 
 ---
 
-## 9. 模型架构（初学者可读版）
+## 9. 模型架构
 
-### 9.1 OpenVLA 是什么
+### 9.1 OpenVLA
 
 OpenVLA 是 Vision-Language-Action（视觉-语言-动作）模型。  
 它把“图像 + 指令文本”映射成“机器人动作”。
 
-### 9.2 核心结构（结合官方说明）
+### 9.2 核心结构
 
 1. 视觉编码器（Vision Backbone）  
    OpenVLA-7B 使用 Prismatic 的 `prism-dinosiglip-224px` 路线，融合 DINOv2 + SigLIP 视觉特征。
@@ -384,16 +383,10 @@ tail -f $OPENVLA_REPO/experiments/logs/EVAL-libero_spatial-openvla-*.txt
 
 ### 10.3 本机当前已观测到的实际结果样例
 
-在 `EVAL-libero_spatial-openvla-2026_04_07-23_13_27.txt` 中，中途统计到：
+- `# episodes completed : 500`
+- `# successes: 411 (82.2%)`
 
-- `# episodes completed so far: 177`
-- `# successes: 152 (85.9%)`
-
-说明：
-
-1. 这是中途结果，不是最终 500 rollout 终值。
-2. 该中途值已接近官方报告量级（Spatial 官方均值约 `84.7% ± 0.9%`）。
-3. 最终结论应以完整 500 回合结果为准。
+该值已接近官方报告量级（Spatial 官方均值约 `84.7% ± 0.9%`）。
 
 ---
 
@@ -461,7 +454,7 @@ kill -9 <PID>
 
 或直接换端口。
 
-### 11.6 TensorFlow / Gym / robosuite Warning 很多
+### 11.6 TensorFlow / Gym / robosuite Warning 
 
 以下通常不是致命错误：
 
@@ -481,7 +474,7 @@ kill -9 <PID>
 
 ---
 
-## 12. 官方数据集说明（和你当前复现的关系）
+## 12. 官方数据集说明
 
 1. 跑官方 `run_libero_eval.py` 评测，核心依赖是 LIBERO 环境、任务定义和官方 checkpoint。
 2. OpenVLA README 中提到的 `modified_libero_rlds`（约 10GB）主要用于微调训练，不是评测必须。
@@ -493,7 +486,7 @@ cd $WORK_ROOT
 git clone https://huggingface.co/datasets/openvla/modified_libero_rlds
 ```
 
-> 作用说明：当你后续要做“再训练/微调”时，这份 RLDS 数据才是关键。
+> 作当后续要做“再训练/微调”时，这份 RLDS 数据是关键
 
 ---
 
@@ -535,9 +528,7 @@ git clone https://huggingface.co/datasets/openvla/modified_libero_rlds
 ---
 
 ## 16. 总结
-
 在 `Ubuntu 20.04 + RTX A5000` 上，本流程已经可以打通：
-
 1. OpenVLA 本地加载与 GPU 推理
 2. LIBERO 官方四套任务的标准评测入口
 3. 日志与视频证据链输出

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
-# OpenVLA 在 Ubuntu 20.04 + RTX A5000 上的完整部署与复现指南（中文实战版）
-
-本 README 是面向初学者的从零复现手册，目标是把 OpenVLA 在本机跑通到可复现实验结果。  
-内容基于官方 OpenVLA/LIBERO 文档，并结合本机真实踩坑过程整理而成。
+# OpenVLA 在 Ubuntu 20.04 + RTX A5000 上的完整部署与复现
+  
+内容基于官方 OpenVLA/LIBERO 文档，并结合本机复现部署过程整理而成。
 
 ---
 
 ## 1. 复现目标与范围
 
-### 1.1 我们要做什么
-
-我们要完成两件事：
+### 1.1 数据集
 
 1. 在本地单机 GPU 上成功加载 OpenVLA 模型并推理。
 2. 按官方方式，在 LIBERO 四个任务套件上运行评测脚本复现：
    - `LIBERO-Spatial`
    - `LIBERO-Object`
    - `LIBERO-Goal`
-   - `LIBERO-10`（又叫 LIBERO-Long）
+   - `LIBERO-10`
 
-### 1.2 本文覆盖的内容
+### 1.2 具体过程
 
 1. 系统与硬件检查
 2. Conda 环境与依赖安装
@@ -44,7 +41,7 @@
 - Driver: `535.183.01`
 - `nvidia-smi` 显示 CUDA Runtime: `12.2`
 
-### 2.3 复现环境关键版本（建议保持一致）
+### 2.3 复现环境版本（建议保持一致）
 
 - Python: `3.10.20`
 - PyTorch: `2.2.0+cu121`
@@ -57,7 +54,7 @@
 - mujoco: `3.1.6`
 - robosuite: `1.4.1`
 
-> 作用说明：这些版本组合是当前已验证可跑通的组合。OpenVLA 对版本比较敏感，特别是 `torch / transformers / flash-attn / numpy`。
+> 这些版本组合是当前已验证可跑通的组合。OpenVLA 对版本比较敏感，特别是 `torch / transformers / flash-attn / numpy`。
 
 ---
 
@@ -87,12 +84,9 @@ openvla_sim/
 │   └── openvla-7b-finetuned-libero-10/
 └── .hf_cache/                    # HuggingFace 下载缓存
 ```
-
-> 作用说明：统一目录能避免路径错乱，且便于汇报、迁移和复现。
-
 ---
 
-## 4. 从零安装环境（一步一步）
+## 4. 从零安装环境
 
 ### 4.1 克隆 OpenVLA
 
@@ -121,8 +115,7 @@ conda run -n openvla pip install "https://github.com/Dao-AILab/flash-attention/r
 cd $OPENVLA_REPO
 conda run -n openvla pip install -e . --no-deps
 ```
-
-> 作用说明：  
+  
 > - `torch + cu121`：确保 GPU 计算可用。  
 > - `requirements-min.txt`：最小推理依赖。  
 > - `flash-attn`：降低显存占用并加速推理。  
@@ -157,7 +150,6 @@ $OPENVLA_PY -m pip install jsonlines matplotlib rich tensorflow==2.15.0 tensorfl
 $OPENVLA_PY -m pip install "numpy<2" "opencv-python<4.12"
 ```
 
-> 作用说明：  
 > - `tensorflow_datasets==4.9.3` 与 `dlimp` 是已知兼容组合。  
 > - `numpy<2` 可规避一批旧依赖兼容问题。  
 > - `opencv-python<4.12` 避免和 numpy 版本冲突。
@@ -242,7 +234,7 @@ ls -lh $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial/model.safetensors.i
 
 ## 7. 官方复现命令（LIBERO）
 
-### 7.1 先做最小烟雾测试（强烈建议）
+### 7.1 先做最小 smoke test
 
 ```bash
 cd $OPENVLA_REPO
@@ -258,9 +250,9 @@ $OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --run_id_note smoke_spatial
 ```
 
-> 作用说明：先验证链路无误（模型加载、环境创建、动作推理、视频保存）再跑 500 次完整评测。
+> 先验证链路无误（模型加载、环境创建、动作推理、视频保存）再跑 500 次完整评测。
 
-### 7.2 四套任务的正式复现（官方入口脚本）
+### 7.2 四套任务的正式复现
 
 #### LIBERO-Spatial
 
@@ -505,7 +497,7 @@ git clone https://huggingface.co/datasets/openvla/modified_libero_rlds
 
 ---
 
-## 13. 一键核对清单（执行前后自检）
+## 13. 执行前后自检
 
 ### 13.1 执行前
 
@@ -550,10 +542,3 @@ git clone https://huggingface.co/datasets/openvla/modified_libero_rlds
 2. LIBERO 官方四套任务的标准评测入口
 3. 日志与视频证据链输出
 4. 常见网络/依赖/端口错误的可执行补救方案
-
-如果你接下来要从“仿真复现”走向“真实 Airbot 部署”，建议下一步做三件事：
-
-1. 先固定相机内参与图像预处理流程，保证输入分布一致。
-2. 用少量真机示教做 LoRA 微调到 Airbot 任务域。
-3. 用当前同一套推理接口（图像+文本->动作）接入真实控制栈，逐步放开速度与动作范围。
-

--- a/README.md
+++ b/README.md
@@ -1,645 +1,559 @@
-# OpenVLA: An Open-Source Vision-Language-Action Model
+# OpenVLA 在 Ubuntu 20.04 + RTX A5000 上的完整部署与复现指南（中文实战版）
 
-[![arXiv](https://img.shields.io/badge/arXiv-2406.09246-df2a2a.svg?style=for-the-badge)](https://arxiv.org/abs/2406.09246)
-[![HF Models](https://img.shields.io/badge/%F0%9F%A4%97-Models-yellow?style=for-the-badge)](https://huggingface.co/openvla/openvla-7b)
-[![PyTorch](https://img.shields.io/badge/PyTorch-2.2.0-EE4C2C.svg?style=for-the-badge&logo=pytorch)](https://pytorch.org/get-started/locally/)
-[![Python](https://img.shields.io/badge/python-3.10-blue?style=for-the-badge)](https://www.python.org)
-[![License](https://img.shields.io/github/license/TRI-ML/prismatic-vlms?style=for-the-badge)](LICENSE)
- 
-[**Getting Started**](#getting-started) | [**Pretrained VLAs**](#pretrained-vlas) | [**Installation**](#installation) | [**Fine-Tuning OpenVLA via LoRA**](#fine-tuning-openvla-via-lora) | [**Fully Fine-Tuning OpenVLA**](#fully-fine-tuning-openvla) |
-[**Training VLAs from Scratch**](#training-vlas-from-scratch) | [**Evaluating OpenVLA**](#evaluating-openvla) | [**Project Website**](https://openvla.github.io/)
-
-
-<hr style="border: 2px solid gray;"></hr>
-
-## Latest Updates
-- [2025-03-03] OFT (Optimized Fine-Tuning recipe for VLAs) was recently released! Compared to vanilla OpenVLA fine-tuning, OFT enables 25-50x faster inference speed, higher task success rates, multiple input images, and high-frequency bimanual robot control. Unlike FAST, OFT uses continuous actions for greater model quality. See project website [here](https://openvla-oft.github.io/).
-- [2025-01-16] The FAST action tokenizer was recently released! Compared to vanilla OpenVLA-style 256-bin action discretization, FAST allows action chunks to be compressed into fewer tokens, speeding up inference by up to 15x when using discrete robot actions. See project website [here](https://www.physicalintelligence.company/research/fast).
-- [2024-10-15] Added a [VLA Performance Troubleshooting](#vla-performance-troubleshooting) section to the README with best practices for debugging poor VLA performance after fine-tuning.
-- [2024-09-04] Added LIBERO simulation benchmark fine-tuning experiments to paper (see v2 on [arXiv](https://arxiv.org/abs/2406.09246));
-  added instructions for reproducing OpenVLA results in [LIBERO Simulation Benchmark Evaluations](#libero-simulation-benchmark-evaluations) section
-- [2024-08-14] Added new section, [Evaluating OpenVLA](#evaluating-openvla), with instructions for running BridgeData V2 WidowX robot evals
-- [2024-07-08] Added new sections: [Fine-Tuning OpenVLA via LoRA](#fine-tuning-openvla-via-lora), [Fully Fine-Tuning OpenVLA](#fully-fine-tuning-openvla)
-- [2024-06-13] Initial release
-
-<hr style="border: 2px solid gray;"></hr>
-
-A simple and scalable codebase for training and fine-tuning vision-language-action models (VLAs) for generalist robotic 
-manipulation:
-
-- **Different Dataset Mixtures**: We natively support arbitrary datasets in RLDS format, including arbitrary mixtures of
-  data from the [Open X-Embodiment Dataset](https://robotics-transformer-x.github.io/).
-- **Easy Scaling**: Powered by PyTorch FSDP and Flash-Attention, we can quickly and efficiently train models from 1B - 
-  34B parameters, with easily adaptable model architectures.
-- **Native Fine-Tuning Support**: Built-in support (with examples) for various forms of fine-tuning (full, 
-  partial, LoRA).
-
-Built on top of [Prismatic VLMs](https://github.com/TRI-ML/prismatic-vlms).
-
-## Getting Started
-
-To get started with loading and running OpenVLA models for inference, we provide a lightweight interface that leverages
-HuggingFace `transformers` AutoClasses, with minimal dependencies.
-
-For example, to load `openvla-7b` for zero-shot instruction following in the
-[BridgeData V2 environments](https://rail-berkeley.github.io/bridgedata/) with a WidowX robot:
-
-```python
-# Install minimal dependencies (`torch`, `transformers`, `timm`, `tokenizers`, ...)
-# > pip install -r https://raw.githubusercontent.com/openvla/openvla/main/requirements-min.txt
-from transformers import AutoModelForVision2Seq, AutoProcessor
-from PIL import Image
-
-import torch
-
-# Load Processor & VLA
-processor = AutoProcessor.from_pretrained("openvla/openvla-7b", trust_remote_code=True)
-vla = AutoModelForVision2Seq.from_pretrained(
-    "openvla/openvla-7b", 
-    attn_implementation="flash_attention_2",  # [Optional] Requires `flash_attn`
-    torch_dtype=torch.bfloat16, 
-    low_cpu_mem_usage=True, 
-    trust_remote_code=True
-).to("cuda:0")
-
-# Grab image input & format prompt
-image: Image.Image = get_from_camera(...)
-prompt = "In: What action should the robot take to {<INSTRUCTION>}?\nOut:"
-
-# Predict Action (7-DoF; un-normalize for BridgeData V2)
-inputs = processor(prompt, image).to("cuda:0", dtype=torch.bfloat16)
-action = vla.predict_action(**inputs, unnorm_key="bridge_orig", do_sample=False)
-
-# Execute...
-robot.act(action, ...)
-```
-
-We also provide an [example script for fine-tuning OpenVLA models for new tasks and 
-embodiments](./vla-scripts/finetune.py); this script supports different fine-tuning modes -- including (quantized) 
-low-rank adaptation (LoRA) supported by [HuggingFace's PEFT library](https://huggingface.co/docs/peft/en/index). 
-
-For deployment, we provide a lightweight script for [serving OpenVLA models over a REST API](./vla-scripts/deploy.py), 
-providing an easy way to integrate OpenVLA models into existing robot control stacks, 
-removing any requirement for powerful on-device compute.
-
-## Pretrained VLAs
-
-We release two OpenVLA models trained as part of our work, with checkpoints, configs, and model cards available [on our
-HuggingFace page](https://huggingface.co/openvla):
-- [`openvla-7b`](https://huggingface.co/openvla/openvla-7b): The flagship model from our paper, trained from 
-  the Prismatic `prism-dinosiglip-224px` VLM (based on a fused DINOv2 and SigLIP vision backbone, and Llama-2 LLM). 
-  Trained on a large mixture of datasets from Open X-Embodiment spanning 970K trajectories 
-  ([mixture details - see "Open-X Magic Soup++"](./prismatic/vla/datasets/rlds/oxe/mixtures.py)).
-- [`openvla-v01-7b`](https://huggingface.co/openvla/openvla-7b-v01): An early model used during development, trained from
-  the Prismatic `siglip-224px` VLM (singular SigLIP vision backbone, and a Vicuña v1.5 LLM). Trained on the same mixture
-  of datasets as [Octo](https://github.com/octo-models/octo), but for significantly fewer GPU hours than our final model 
-  ([mixture details - see "Open-X Magic Soup"](./prismatic/vla/datasets/rlds/oxe/mixtures.py)).
-
-**Explicit Notes on Model Licensing & Commercial Use**: While all code in this repository is released under an MIT 
-License, our pretrained models may inherit restrictions from the underlying base models we use. Specifically, both the
-above models are derived from Llama-2, and as such are subject to the 
-[Llama Community License](https://ai.meta.com/llama/license/).
+本 README 是面向初学者的从零复现手册，目标是把 OpenVLA 在本机跑通到可复现实验结果。  
+内容基于官方 OpenVLA/LIBERO 文档，并结合本机真实踩坑过程整理而成。
 
 ---
 
-## Installation
+## 1. 复现目标与范围
 
-> **Note**: These installation instructions are for full-scale pretraining (and distributed fine-tuning); if looking to
-  just run inference with OpenVLA models (or perform lightweight fine-tuning), see instructions above!
+### 1.1 我们要做什么
 
-This repository was built using Python 3.10, but should be backwards compatible with any Python >= 3.8. We require
-PyTorch 2.2.* -- installation instructions [can be found here](https://pytorch.org/get-started/locally/). The latest 
-version of this repository was developed and thoroughly tested with:
-  - PyTorch 2.2.0, torchvision 0.17.0, transformers 4.40.1, tokenizers 0.19.1, timm 0.9.10, and flash-attn 2.5.5
+我们要完成两件事：
 
-**[5/21/24] Note**: Following reported regressions and breaking changes in later versions of `transformers`, `timm`, and
-`tokenizers` we explicitly pin the above versions of the dependencies. We are working on implementing thorough tests, 
-and plan on relaxing these constraints as soon as we can.
+1. 在本地单机 GPU 上成功加载 OpenVLA 模型并推理。
+2. 按官方方式，在 LIBERO 四个任务套件上运行评测脚本复现：
+   - `LIBERO-Spatial`
+   - `LIBERO-Object`
+   - `LIBERO-Goal`
+   - `LIBERO-10`（又叫 LIBERO-Long）
 
-Use the setup commands below to get started:
+### 1.2 本文覆盖的内容
+
+1. 系统与硬件检查
+2. Conda 环境与依赖安装
+3. OpenVLA 与 LIBERO 仓库准备
+4. 权重与数据下载（含断点续传、代理、报错补救）
+5. 官方评测命令（smoke test + full eval）
+6. 推理结果读取方法
+7. 常见错误与修复
+8. 模型架构与每一步操作作用解释
+
+---
+
+## 2. 机器配置（本机实测）
+
+### 2.1 操作系统与内核
+
+- Ubuntu 20.04.6 LTS
+- Kernel: `5.15.0-139-generic`
+
+### 2.2 GPU 与驱动
+
+- GPU: `NVIDIA RTX A5000`（24GB 显存）
+- Driver: `535.183.01`
+- `nvidia-smi` 显示 CUDA Runtime: `12.2`
+
+### 2.3 复现环境关键版本（建议保持一致）
+
+- Python: `3.10.20`
+- PyTorch: `2.2.0+cu121`
+- transformers: `4.40.1`
+- tokenizers: `0.19.1`
+- timm: `0.9.10`
+- flash-attn: `2.5.5`
+- tensorflow: `2.15.0`
+- tensorflow_datasets: `4.9.3`
+- mujoco: `3.1.6`
+- robosuite: `1.4.1`
+
+> 作用说明：这些版本组合是当前已验证可跑通的组合。OpenVLA 对版本比较敏感，特别是 `torch / transformers / flash-attn / numpy`。
+
+---
+
+## 3. 目录规划（建议）
+
+建议统一工作根目录：
 
 ```bash
-# Create and activate conda environment
-conda create -n openvla python=3.10 -y
-conda activate openvla
+export WORK_ROOT=/mnt/data/home/yqy/YANGCHENX/openvla_sim
+export OPENVLA_REPO=$WORK_ROOT/openvla
+export LIBERO_ROOT=$WORK_ROOT/LIBERO
+export OPENVLA_PY=/mnt/data/home/yqy/miniforge3/envs/openvla/bin/python
+export HF_HOME=$WORK_ROOT/.hf_cache
+```
 
-# Install PyTorch. Below is a sample command to do this, but you should check the following link
-# to find installation instructions that are specific to your compute platform:
-# https://pytorch.org/get-started/locally/
-conda install pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch -c nvidia -y  # UPDATE ME!
+建议目录结构：
 
-# Clone and install the openvla repo
+```text
+openvla_sim/
+├── openvla/                      # OpenVLA 主仓库
+├── LIBERO/                       # LIBERO 仓库
+├── models/                       # 本地模型权重
+│   ├── openvla-7b/
+│   ├── openvla-7b-finetuned-libero-spatial/
+│   ├── openvla-7b-finetuned-libero-object/
+│   ├── openvla-7b-finetuned-libero-goal/
+│   └── openvla-7b-finetuned-libero-10/
+└── .hf_cache/                    # HuggingFace 下载缓存
+```
+
+> 作用说明：统一目录能避免路径错乱，且便于汇报、迁移和复现。
+
+---
+
+## 4. 从零安装环境（一步一步）
+
+### 4.1 克隆 OpenVLA
+
+```bash
+mkdir -p $WORK_ROOT
+cd $WORK_ROOT
 git clone https://github.com/openvla/openvla.git
-cd openvla
-pip install -e .
-
-# Install Flash Attention 2 for training (https://github.com/Dao-AILab/flash-attention)
-#   =>> If you run into difficulty, try `pip cache remove flash_attn` first
-pip install packaging ninja
-ninja --version; echo $?  # Verify Ninja --> should return exit code "0"
-pip install "flash-attn==2.5.5" --no-build-isolation
 ```
 
-If you run into any problems during the installation process, please file a GitHub Issue.
-
-**Note:** See `vla-scripts/` for full training and verification scripts for OpenVLA models. Note that `scripts/` is
-mostly a holdover from the original (base) `prismatic-vlms` repository, with support for training and evaluating
-visually-conditioned language models; while you can use this repo to train VLMs AND VLAs, note that trying to generate
-language (via `scripts/generate.py`) with existing OpenVLA models will not work (as we only train current OpenVLA models
-to generate actions, and actions alone).
-
-## Fine-Tuning OpenVLA via LoRA
-
-**(2025-03-03 Update: We recommend trying the new OFT recipe for fine-tuning OpenVLA to produce faster and more successful policies. See project website [here](https://openvla-oft.github.io/).)**
-
-In this section, we discuss fine-tuning OpenVLA using Low-Rank Adaptation (LoRA) via the Hugging Face `transformers` library,
-which is recommended if you do not have sufficient compute to fully fine-tune a 7B-parameter model. The main script for LoRA
-fine-tuning is `vla-scripts/finetune.py`. (If you instead wish to do full fine-tuning, please see the
-[Fully Fine-Tuning OpenVLA](#fully-fine-tuning-openvla) section.)
-
-Below we show an example of how you can fine-tune the main OpenVLA checkpoint ([`openvla-7b`](https://huggingface.co/openvla/openvla-7b))
-via LoRA. Here we fine-tune on [BridgeData V2](https://rail-berkeley.github.io/bridgedata/) using a single A100
-GPU with 80 GB VRAM. (You can also fine-tune with a smaller GPU, as long as it has at least ~27 GB of memory,
-by modifying the batch size.)
-
-First, download the BridgeData V2 dataset:
+### 4.2 创建 Conda 环境
 
 ```bash
-# Change directory to your base datasets folder
-cd <PATH TO BASE DATASETS DIR>
-
-# Download the full dataset (124 GB)
-wget -r -nH --cut-dirs=4 --reject="index.html*" https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
-
-# Rename the dataset to `bridge_orig` (NOTE: Omitting this step may lead to runtime errors later)
-mv bridge_dataset bridge_orig
+conda create -n openvla python=3.10 -y
 ```
 
-Now, launch the LoRA fine-tuning script, as shown below. Note that `--batch_size==16` with `--grad_accumulation_steps==1`
-requires ~72 GB GPU memory. If you have a smaller GPU, you should reduce `--batch_size` and increase `--grad_accumulation_steps`
-to maintain an effective batch size that is large enough for stable training. If you have multiple GPUs and wish to train via
-PyTorch Distributed Data Parallel (DDP), simply set `--nproc-per-node` in the `torchrun` command below to the number of available GPUs.
+### 4.3 安装核心推理依赖（GPU）
 
 ```bash
-torchrun --standalone --nnodes 1 --nproc-per-node 1 vla-scripts/finetune.py \
-  --vla_path "openvla/openvla-7b" \
-  --data_root_dir <PATH TO BASE DATASETS DIR> \
-  --dataset_name bridge_orig \
-  --run_root_dir <PATH TO LOG/CHECKPOINT DIR> \
-  --adapter_tmp_dir <PATH TO TEMPORARY DIR TO SAVE ADAPTER WEIGHTS> \
-  --lora_rank 32 \
-  --batch_size 16 \
-  --grad_accumulation_steps 1 \
-  --learning_rate 5e-4 \
-  --image_aug <True or False> \
-  --wandb_project <PROJECT> \
-  --wandb_entity <ENTITY> \
-  --save_steps <NUMBER OF GRADIENT STEPS PER CHECKPOINT SAVE>
+conda run -n openvla pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --index-url https://download.pytorch.org/whl/cu121
+conda run -n openvla pip install "numpy<2"
+cd $OPENVLA_REPO
+conda run -n openvla pip install -r requirements-min.txt
+conda run -n openvla pip install draccus==0.8.0 json-numpy fastapi uvicorn pillow accelerate==0.30.1 peft==0.11.1 einops sentencepiece==0.1.99
+conda run -n openvla pip install packaging ninja
+conda run -n openvla pip install "https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.5/flash_attn-2.5.5+cu122torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl"
+cd $OPENVLA_REPO
+conda run -n openvla pip install -e . --no-deps
 ```
 
-Note: If you set `--image_aug==False` in the command above, you will observe nearly 100% `action_accuracy` in the training logs,
-since the [`openvla-7b`](https://huggingface.co/openvla/openvla-7b) model is already pretrained (without augmentations) on a
-superset of datasets that includes BridgeData V2.
+> 作用说明：  
+> - `torch + cu121`：确保 GPU 计算可用。  
+> - `requirements-min.txt`：最小推理依赖。  
+> - `flash-attn`：降低显存占用并加速推理。  
+> - `pip install -e .`：把当前仓库作为可编辑包安装，脚本可直接调用内部模块。
 
-To LoRA fine-tune on a different dataset, you can download the dataset from the [Open X-Embodiment (OXE)](https://robotics-transformer-x.github.io/)
-mixture (see [this custom script](https://github.com/moojink/rlds_dataset_mod/blob/main/prepare_open_x.sh) for an example of how to download datasets
-from OXE). Alternatively, if you have a custom dataset that is not part of OXE, you can either (a) convert the dataset to the RLDS format which is
-compatible with our fine-tuning script (see [this repo](https://github.com/kpertsch/rlds_dataset_builder) for instructions on this), or (b) use your own
-custom PyTorch Dataset wrapper (see comments in `vla-scripts/finetune.py` for instructions). We recommend option (a) for most users; the RLDS dataset and
-dataloader are tested more extensively since we used these for all of our pretraining and fine-tuning experiments.
-
-For option (a), after you converted your dataset to RLDS, you need to register it with our data loader, by registering a dataset
-config [here](prismatic/vla/datasets/rlds/oxe/configs.py#L54) and a dataset transform function [here](prismatic/vla/datasets/rlds/oxe/transforms.py#L828).
-
-Once you have integrated your new dataset, you can launch LoRA fine-tuning with the same `vla-scripts/finetune.py` script above. If you run into any issues,
-please visit the [VLA Troubleshooting](#vla-troubleshooting) section or search for a similar issue in the [OpenVLA GitHub Issues page](https://github.com/openvla/openvla/issues?q=)
-(including "Closed" issues). If you cannot find a similar issue there, feel free to create a new issue.
-
-## Fully Fine-Tuning OpenVLA
-
-**(2025-03-03 Update: We recommend trying the new OFT recipe for fine-tuning OpenVLA to produce faster and more successful policies. See project website [here](https://openvla-oft.github.io/).)**
-
-In this section, we discuss <ins>fully fine-tuning</ins> OpenVLA (all 7.5 billion parameters) via native PyTorch Fully Sharded Data Parallel (FSDP)
-using the [Prismatic VLMs](https://github.com/TRI-ML/prismatic-vlms) training script. Full fine-tuning is more advanced/involved and is only recommended
-if you have sufficient compute (e.g., a full node of 8 A100 GPUs) and if LoRA fine-tuning is insufficient for your use case (e.g., if the fine-tuning distribution
-varies drastically from the pretraining distribution). Otherwise, we recommend that you try parameter-efficient fine-tuning via LoRA, which is described in the 
-[Fine-Tuning OpenVLA via LoRA](#fine-tuning-openvla-via-lora) section.
-
-For full fine-tuning, you will need to download [a different version of the OpenVLA model checkpoint](https://huggingface.co/openvla/openvla-7b-prismatic) that is compatible
-with the Prismatic VLMs codebase, which we built on top of to develop the OpenVLA model. You can download this Prismatic-compatible OpenVLA checkpoint using the git commands below
-(alternatively, you can download via the [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli)):
+### 4.4 检查 GPU 与 Python 环境是否正常
 
 ```bash
-# Change directory to your base model checkpoints folder
-cd <PATH TO BASE MODEL CHECKPOINTS DIR>
-
-# Download checkpoint (30 GB) -- may take a few minutes
-git clone git@hf.co:openvla/openvla-7b-prismatic
-
-# If the command above did not download the full checkpoint,
-# manually fetch it via git Large File Storage (LFS)
-# Note: You may have to configure an SSH key for this to work
-cd openvla-7b-prismatic
-git lfs fetch --all
+nvidia-smi
+conda run -n openvla python -c "import torch; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
 ```
-
-We show how you can fully fine-tune OpenVLA on [BridgeData V2](https://rail-berkeley.github.io/bridgedata/) using a single node with 8 GPUs. If you wish to
-use a different number of GPUs (or nodes), you can modify the VLA training configuration in [`prismatic/conf/vla.py`](prismatic/conf/vla.py).
-
-Download the BridgeData V2 dataset:
-
-```bash
-# Change directory to your base datasets folder
-cd <PATH TO BASE DATASETS DIR>
-
-# Download the full dataset (124 GB)
-wget -r -nH --cut-dirs=4 --reject="index.html*" https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
-
-# Rename the dataset to `bridge_orig` (NOTE: Omitting this step may lead to runtime errors later)
-mv bridge_dataset bridge_orig
-```
-
-Next, create a [Hugging Face user access token](https://huggingface.co/docs/hub/en/security-tokens) and copy the token value (a string that starts with
-`hf_...`) into a file named `.hf_token` at the root directory of this repo (`openvla/.hf_token`).
-
-```bash
-# Go to openvla root directory
-cd openvla
-
-# Copy HF token value into token file. Replace "hf_..." with your own token value!
-# See: https://huggingface.co/docs/hub/en/security-tokens
-echo hf_... >>> .hf_token
-```
-
-Now, launch the training script. If you wish to use a different number of nodes or GPUs, modify the VLA training configuration in
-[`prismatic/conf/vla.py`](prismatic/conf/vla.py) and then change the `--nnodes` and `--nproc-per-node` arguments below accordingly.
-
-```bash
-torchrun --standalone --nnodes 1 --nproc-per-node 8 vla-scripts/train.py \
-  --pretrained_checkpoint <PATH TO openvla/openvla-7b-prismatic CHECKPOINT FILE: step-295000-epoch-40-loss=0.2200.pt> \
-  --vla.type prism-dinosiglip-224px+mx-bridge \
-  --data_root_dir <PATH TO BASE DATASETS DIR> \
-  --run_root_dir <PATH TO LOG/CHECKPOINT DIR> \
-  --run_id <OPTIONAL RUN ID FOR WANDB LOGGING> \
-  --image_aug <True or False> \
-  --wandb_project <PROJECT> \
-  --wandb_entity <ENTITY> \
-  --save_interval <NUMBER OF GRADIENT STEPS PER CHECKPOINT SAVE> \
-  --is_resume False
-```
-
-Note that the `--is_resume` argument is set to `False` above since we are fine-tuning a pretrained checkpoint rather than resuming a paused training run.
-
-If your training run gets paused and you wish to resume from the latest checkpoint, change `--pretrained_checkpoint` to the latest checkpoint path,
-and then set `--is_resume==True` and specify `--resume_step` and `--resume_epoch` as the step and epoch number, respectively. For example, if you wish to
-resume training from a checkpoint named `step-010000-epoch-20-loss=0.0160.pt`, you would set `is_resume==True`, `resume_step==10000`, and `resume_epoch==20`.
-
-Note: If you run the BridgeData V2 fine-tuning command above, you should observe nearly 100% Action Token Accuracy in the training logs, since the
-[`openvla-7b`](https://huggingface.co/openvla/openvla-7b) model is already pretrained on a superset of datasets that includes BridgeData V2.
-
-To fully fine-tune OpenVLA on a different dataset, you can download the dataset from the [Open X-Embodiment (OXE)](https://robotics-transformer-x.github.io/)
-mixture (see [this custom script](https://github.com/moojink/rlds_dataset_mod/blob/main/prepare_open_x.sh) for an example of how to download datasets from OXE).
-Alternatively, if you have a custom dataset that is not part of OXE, you can convert the dataset to the RLDS format, which is compatible with our fine-tuning script
-(see [this repo](https://github.com/kpertsch/rlds_dataset_builder) for instructions on this). After downloading/converting the dataset, you will need to modify the following files:
-
-* [`prismatic/conf/vla.py`](prismatic/conf/vla.py): Add a new training configuration by creating an experiment class, and then register it in the `VLARegistry` at the bottom of the file.
-  * Make sure to create a new unique `vla_id` for your fine-tuning run, and adjust some configuration variables as needed – e.g., `expected_world_size` (number of GPUs),
-  `per_device_batch_size` (batch size per GPU), `global_batch_size` (total batch size), `shuffle_buffer_size` (number of samples in shuffle buffer per GPU), etc. See comments
-  under the `VLAConfig` class at the top of the file to understand the purpose of each variable.
-* [`prismatic/vla/datasets/rlds/oxe/mixtures.py`](prismatic/vla/datasets/rlds/oxe/mixtures.py): Define a new mixture for your fine-tuning mixture in the `OXE_NAMED_MIXTURES` dictionary.
-* [`prismatic/vla/datasets/rlds/oxe/transforms.py`](prismatic/vla/datasets/rlds/oxe/transforms.py): Define a new dataset transform function for your fine-tuning dataset, and add it to the
-`OXE_STANDARDIZATION_TRANSFORMS` registry at the bottom of the file.
-* [`prismatic/vla/datasets/rlds/oxe/configs.py`](prismatic/vla/datasets/rlds/oxe/configs.py): Add a new configuration specifying your fine-tuning dataset's observation and action spaces
-to the `OXE_DATASET_CONFIGS` dictionary.
-
-After completing the steps above, you can start full fine-tuning using the `vla-scripts/train.py` script. Make sure to set the `--vla.type` argument to the new `vla_id` that you added in `prismatic/conf/vla.py`.
-
-When you are finished with fine-tuning, you will need to convert the final model checkpoint to a version that is
-compatible with the Hugging Face `transformers` library. See the [Converting Prismatic Models to Hugging Face](#converting-prismatic-models-to-hugging-face) section for instructions.
-
-If you run into any issues, please visit the [VLA Troubleshooting](#vla-troubleshooting) section or search for a similar issue in the
-[OpenVLA GitHub Issues page](https://github.com/openvla/openvla/issues?q=) (including "Closed" issues). If you cannot find a similar issue there, feel free to create a new issue.
-
-### Converting Prismatic Models to Hugging Face
-
-If you have used the Prismatic VLMs codebase to train your model (e.g., if you did full fine-tuning of OpenVLA on a
-new dataset), you will need to convert the final checkpoint to a version that is compatible with Hugging Face
-`transformers` AutoClasses. We discuss how to do so in this section.
-
-Let's say your training run directory is `PRISMATIC_RUN_DIR` (e.g., `prism-dinosiglip-224px+mx-oxe-magic-soup-plus+n8+b32+x7`).
-Inside this directory, there should be a directory called `checkpoints` which contains saved model checkpoints (e.g.,
-`step-295000-epoch-40-loss=0.2200.pt`). The Prismatic-to-Hugging-Face conversion script
-([convert_openvla_weights_to_hf.py](vla-scripts/extern/convert_openvla_weights_to_hf.py)) expects a checkpoint file
-named `latest-checkpoint.pt`. Therefore, you should first create a symbolic link called `latest-checkpoint.pt` that
-points to the checkpoint file that you wish to convert:
-
-```bash
-# Go to your Prismatic training run's `checkpoints` directory
-cd PRISMATIC_RUN_DIR/checkpoints
-
-# Create symbolic link pointing to your checkpoint file
-ln -s <YOUR CHECKPOINT FILENAME> latest-checkpoint.pt
-```
-
-Then, launch the conversion script to convert the checkpoint from the Prismatic VLMs format to the Hugging Face format:
-
-```bash
-python vla-scripts/extern/convert_openvla_weights_to_hf.py \
-    --openvla_model_path_or_id <PRISMATIC_RUN_DIR> \
-    --output_hf_model_local_path <OUTPUT DIR FOR CONVERTED CHECKPOINT>
-```
-
-The command above will save the HF-compatible checkpoint in `output_hf_model_local_path`. Now you can load the checkpoint
-with HF AutoClasses as normal, as shown below. Note that there is an additional necessary step to register the OpenVLA model
-to HF AutoClasses before loading it because you are loading a locally saved checkpoint rather than one that is pushed to the
-HF Hub (see [here](https://huggingface.co/docs/transformers/en/custom_models#registering-a-model-with-custom-code-to-the-auto-classes)
-for details).
-
-```python
-import torch
-from transformers import AutoConfig, AutoImageProcessor, AutoModelForVision2Seq, AutoProcessor
-
-from prismatic.extern.hf.configuration_prismatic import OpenVLAConfig
-from prismatic.extern.hf.modeling_prismatic import OpenVLAForActionPrediction
-from prismatic.extern.hf.processing_prismatic import PrismaticImageProcessor, PrismaticProcessor
-
-# Register OpenVLA model to HF AutoClasses (not needed if you pushed model to HF Hub)
-AutoConfig.register("openvla", OpenVLAConfig)
-AutoImageProcessor.register(OpenVLAConfig, PrismaticImageProcessor)
-AutoProcessor.register(OpenVLAConfig, PrismaticProcessor)
-AutoModelForVision2Seq.register(OpenVLAConfig, OpenVLAForActionPrediction)
-
-# Load Processor & VLA
-processor = AutoProcessor.from_pretrained("<PATH TO CONVERTED CHECKPOINT DIR>", trust_remote_code=True)
-vla = AutoModelForVision2Seq.from_pretrained(
-    "<PATH TO CONVERTED CHECKPOINT DIR>",
-    attn_implementation="flash_attention_2",  # [Optional] Requires `flash_attn`
-    torch_dtype=torch.bfloat16,
-    low_cpu_mem_usage=True,
-    trust_remote_code=True,
-).to("cuda:0")
-
-...
-```
-
-## Training VLAs from Scratch
-
-We provide full instructions and configurations for training VLA models on (arbitrary subsets of) the
-[Open X-Embodiment (OXE) Dataset](https://robotics-transformer-x.github.io/). If you run in to any issues with 
-the following, see [VLA Troubleshooting](#vla-troubleshooting) below (or file a GitHub Issue).
-
-### VLA Pretraining Datasets
-
-We download and preprocess individual datasets from Open X-Embodiment in [RLDS format](https://github.com/google-research/rlds) following 
-[this custom script](https://github.com/moojink/rlds_dataset_mod/blob/main/prepare_open_x.sh). See 
-[mixtures.py](./prismatic/vla/datasets/rlds/oxe/mixtures.py) for the full list of component datasets (and mixture 
-weights) we use to train `openvla-7b`. 
-- **Important**: For the BridgeData V2 component, the version in OXE is out of date (as of 12/20/2023). Instead,
-  you should download the dataset from the [official website](https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/) and place it under the subdirectory `bridge_orig/`. 
-  Replace any reference to `bridge` in the OXE code with `bridge_orig`.
-
-### VLA Configuration & Training Script
-
-The entry point for VLA training is [`vla-scripts/train.py`](vla-scripts/train.py). We use 
-[`draccus`](https://pypi.org/project/draccus) to provide a modular, dataclass-based interface for specifying VLA 
-training configurations; existing VLA configurations are in [`prismatic/conf/vla.py`](prismatic/conf/vla.py). You can 
-add your own training configuration and refer to it using the `--vla.type` command line argument.
-
-We use PyTorch Fully Sharded Data Parallel (FSDP) to distribute training across GPUs. Launch training via `torchrun`:
-
-```bash
-# Train VLA on BridgeData V2 with the Prismatic DINO-SigLIP 224px Backbone on a Single Node (w/ 8 GPUs)
-torchrun --standalone --nnodes 1 --nproc-per-node 8 vla-scripts/train.py \
-  --vla.type "prism-dinosiglip-224px+mx-bridge" \
-  --data_root_dir <PATH TO OXE DATA ROOT> \
-  --run_root_dir <PATH TO LOG/CHECKPOINT ROOT> \
-  --wandb_project "<PROJECT>" \
-  --wandb_entity "<ENTITY>"
-```
-
-### VLA Troubleshooting
-
-The following are a list of known problems and corresponding fixes:
-
-```bash
-FileNotFoundError: Failed to construct dataset "fractal20220817_data", builder_kwargs "{'data_dir': '/path/to/processed/datasets/'}": Could not load dataset info from fractal20220817_data/0.1.0/dataset_info.json
-```
-- **Fix**: Downgrade `tensorflow-datasets` via `pip install tensorflow-datasets==4.9.3`.
-
-
-```bash
-AttributeError: 'DLataset' object has no attribute 'traj_map'. Did you mean: 'flat_map'?
-```
-- **Fix**: Upgrade `dlimp` to the newest version. You may have to `--force-reinstall` like so:
-`pip install --no-deps --force-reinstall git+https://github.com/moojink/dlimp_openvla`
 
 ---
 
-## Evaluating OpenVLA
+## 5. 安装 LIBERO 评测环境
 
-### BridgeData V2 WidowX Evaluations
-
-#### Setup
-
-Clone the [BridgeData V2 WidowX controller repo](https://github.com/rail-berkeley/bridge_data_robot) and install the `widowx_envs` package:
+### 5.1 克隆并安装 LIBERO
 
 ```bash
-git clone https://github.com/rail-berkeley/bridge_data_robot.git
-cd bridge_data_robot
-pip install -e widowx_envs
+git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git $LIBERO_ROOT
+cd $LIBERO_ROOT
+$OPENVLA_PY -m pip install -e . --config-settings editable_mode=compat
 ```
 
-Additionally, install the [`edgeml`](https://github.com/youliangtan/edgeml) library:
+### 5.2 安装 OpenVLA-LIBERO 额外依赖
+
 ```bash
-git clone https://github.com/youliangtan/edgeml.git
-cd edgeml
-pip install -e .
+cd $OPENVLA_REPO
+$OPENVLA_PY -m pip install -r experiments/robot/libero/libero_requirements.txt
+$OPENVLA_PY -m pip install wandb
+$OPENVLA_PY -m pip install jsonlines matplotlib rich tensorflow==2.15.0 tensorflow_datasets==4.9.3 tensorflow_graphics==2021.12.3 "dlimp @ git+https://github.com/moojink/dlimp_openvla"
+$OPENVLA_PY -m pip install "numpy<2" "opencv-python<4.12"
 ```
 
-Follow the instructions in the `bridge_data_robot` README to create the Bridge WidowX Docker container.
+> 作用说明：  
+> - `tensorflow_datasets==4.9.3` 与 `dlimp` 是已知兼容组合。  
+> - `numpy<2` 可规避一批旧依赖兼容问题。  
+> - `opencv-python<4.12` 避免和 numpy 版本冲突。
 
-#### Launching BridgeData V2 Evaluations
-
-There are multiple ways to run BridgeData V2 evaluations. We describe the server-client method below.
-
-In one Terminal window (e.g., in tmux), start the WidowX Docker container:
+### 5.3 初始化 LIBERO 配置文件（避免首次交互中断）
 
 ```bash
-cd bridge_data_robot
-./generate_usb_config.sh
-USB_CONNECTOR_CHART=$(pwd)/usb_connector_chart.yml docker compose up --build robonet
+mkdir -p /mnt/data/home/yqy/.libero
+cat > /mnt/data/home/yqy/.libero/config.yaml <<'YAML'
+benchmark_root: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero
+bddl_files: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./bddl_files
+init_states: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./init_files
+datasets: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/../datasets
+assets: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./assets
+YAML
+mkdir -p /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/datasets
 ```
 
-In a second Terminal window, run the WidowX robot server:
+> 作用说明：LIBERO 首次导入会询问路径；提前写好配置后，脚本可非交互运行。
+
+---
+
+## 6. 模型权重下载（官方 checkpoint）
+
+### 6.1 需要下载哪些权重
+
+1. 基础模型（可选但推荐）：`openvla/openvla-7b`
+2. LIBERO 四个官方微调模型（复现核心）：
+   - `openvla/openvla-7b-finetuned-libero-spatial`
+   - `openvla/openvla-7b-finetuned-libero-object`
+   - `openvla/openvla-7b-finetuned-libero-goal`
+   - `openvla/openvla-7b-finetuned-libero-10`
+
+### 6.2 下载前建议环境变量
 
 ```bash
-cd bridge_data_robot
-docker compose exec robonet bash -lic "widowx_env_service --server"
+export WORK_ROOT=/mnt/data/home/yqy/YANGCHENX/openvla_sim
+export HF_HOME=$WORK_ROOT/.hf_cache
+export HF_HUB_DISABLE_XET=1
+export HF_HUB_ENABLE_HF_TRANSFER=0
 ```
 
-In a third Terminal window, run the OpenVLA policy evaluation script:
+如果你走代理，另外加上：
 
 ```bash
-cd openvla
-python experiments/robot/bridge/run_bridgev2_eval.py \
+export HTTP_PROXY=http://127.0.0.1:7897
+export HTTPS_PROXY=http://127.0.0.1:7897
+export http_proxy=$HTTP_PROXY
+export https_proxy=$HTTPS_PROXY
+```
+
+> 作用说明：  
+> - `HF_HUB_ENABLE_HF_TRANSFER=0`：下载失败时错误信息更清晰，且常比 hf_transfer 稳。  
+> - `HF_HUB_DISABLE_XET=1`：避免部分网络环境对 xet/cas 链路不稳定。
+
+### 6.3 下载命令（逐个执行，支持断点续传）
+
+```bash
+mkdir -p $WORK_ROOT/models
+
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/huggingface-cli download openvla/openvla-7b --local-dir $WORK_ROOT/models/openvla-7b
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/huggingface-cli download openvla/openvla-7b-finetuned-libero-spatial --local-dir $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/huggingface-cli download openvla/openvla-7b-finetuned-libero-object --local-dir $WORK_ROOT/models/openvla-7b-finetuned-libero-object
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/huggingface-cli download openvla/openvla-7b-finetuned-libero-goal --local-dir $WORK_ROOT/models/openvla-7b-finetuned-libero-goal
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/huggingface-cli download openvla/openvla-7b-finetuned-libero-10 --local-dir $WORK_ROOT/models/openvla-7b-finetuned-libero-10
+```
+
+> 说明：如果你的环境没有 `hf` 命令，用 `huggingface-cli` 是正常的。
+
+### 6.4 如何判断权重是否下载完整
+
+检查某个 checkpoint 是否具备全部分片和索引文件：
+
+```bash
+ls -lh $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial/model-0000*-of-00004.safetensors
+ls -lh $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial/model.safetensors.index.json
+```
+
+如果 4 个分片 + `model.safetensors.index.json` 都存在，通常即可本地加载。
+
+---
+
+## 7. 官方复现命令（LIBERO）
+
+### 7.1 先做最小烟雾测试（强烈建议）
+
+```bash
+cd $OPENVLA_REPO
+export HF_HOME=$WORK_ROOT/.hf_cache
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --model_family openvla \
-  --pretrained_checkpoint openvla/openvla-7b
+  --pretrained_checkpoint $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial \
+  --task_suite_name libero_spatial \
+  --center_crop True \
+  --num_trials_per_task 1 \
+  --use_wandb False \
+  --seed 7 \
+  --run_id_note smoke_spatial
 ```
 
-If you run into an error such as `ModuleNotFoundError: No module named 'moviepy.editor'`, you can work around it by fixing the
-moviepy version to an older version, v1.0.3, in the bridge_data_robot repo's requirements.txt file
-[here](https://github.com/rail-berkeley/bridge_data_robot/blob/main/widowx_envs/requirements.txt). I.e., simply replace `moviepy`
-with `moviepy==1.0.3` in the requirements.txt file. Then, go back to the first step above and restart the WidowX Docker container;
-it should be rebuilt with the older moviepy version.
+> 作用说明：先验证链路无误（模型加载、环境创建、动作推理、视频保存）再跑 500 次完整评测。
 
+### 7.2 四套任务的正式复现（官方入口脚本）
 
-### LIBERO Simulation Benchmark Evaluations
-
-In the [updated OpenVLA paper (v2)](https://arxiv.org/abs/2406.09246), we discuss fine-tuning OpenVLA
-on a simulated benchmark, [LIBERO](https://libero-project.github.io/main.html), in Appendix E.
-Please see the paper for details, such as how we modify the provided demonstration datasets to
-improve the overall performance of all methods.
-
-We copy the results to the section below and then discuss how to reproduce the results for OpenVLA.
-
-#### OpenVLA Fine-Tuning Results
-
-| Method | LIBERO-Spatial | LIBERO-Object | LIBERO-Goal | LIBERO-Long | Average |
-|--------|----------------|---------------|-------------|-------------|---------|
-| Diffusion Policy from scratch | 78.3 ± 1.1% | **92.5 ± 0.7%** | 68.3 ± 1.2% | 50.5 ± 1.3% | 72.4 ± 0.7% |
-| Octo fine-tuned | 78.9 ± 1.0% | 85.7 ± 0.9% | **84.6 ± 0.9%** | 51.1 ± 1.3% | 75.1 ± 0.6% |
-| OpenVLA fine-tuned (ours) | **84.7 ± 0.9%** | 88.4 ± 0.8% | 79.2 ± 1.0% | **53.7 ± 1.3%** | **76.5 ± 0.6%** |
-
-Each success rate is the average over 3 random seeds x 500 rollouts each (10 tasks x 50 rollouts per task).
-
-#### LIBERO Setup
-
-Clone and install the [LIBERO repo](https://github.com/Lifelong-Robot-Learning/LIBERO):
+#### LIBERO-Spatial
 
 ```bash
-git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git
-cd LIBERO
-pip install -e .
-```
-
-Additionally, install other required packages:
-```bash
-cd openvla
-pip install -r experiments/robot/libero/libero_requirements.txt
-```
-
-(Optional) To download the modified versions of the LIBERO datasets that we used in our fine-tuning
-experiments, run the command below. This will download the LIBERO-Spatial, LIBERO-Object, LIBERO-Goal,
-and LIBERO-10 datasets in RLDS data format (~10 GB total). You can use these to fine-tune OpenVLA or
-train other methods. This step is optional since we provide pretrained OpenVLA checkpoints below.
-(Also, you can find the script we used to generate the modified datasets in raw HDF5 format
-[here](experiments/robot/libero/regenerate_libero_dataset.py) and the code we used to convert these
-datasets to the RLDS format [here](https://github.com/moojink/rlds_dataset_builder).)
-```bash
-git clone git@hf.co:datasets/openvla/modified_libero_rlds
-```
-
-#### Launching LIBERO Evaluations
-
-We fine-tuned OpenVLA via LoRA (r=32) on four LIBERO task suites independently: LIBERO-Spatial, LIBERO-Object, LIBERO-Goal, and LIBERO-10 (also called LIBERO-Long).
-The four checkpoints are available on Hugging Face:
-* [openvla/openvla-7b-finetuned-libero-spatial](https://huggingface.co/openvla/openvla-7b-finetuned-libero-spatial)
-* [openvla/openvla-7b-finetuned-libero-object](https://huggingface.co/openvla/openvla-7b-finetuned-libero-object)
-* [openvla/openvla-7b-finetuned-libero-goal](https://huggingface.co/openvla/openvla-7b-finetuned-libero-goal)
-* [openvla/openvla-7b-finetuned-libero-10](https://huggingface.co/openvla/openvla-7b-finetuned-libero-10)
-
-To start evaluation with one of these checkpoints, run one of the commands below. Each will automatically download the appropriate checkpoint listed above.
-
-```bash
-# Launch LIBERO-Spatial evals
-python experiments/robot/libero/run_libero_eval.py \
+cd $OPENVLA_REPO
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --model_family openvla \
-  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-spatial \
+  --pretrained_checkpoint $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial \
   --task_suite_name libero_spatial \
   --center_crop True
+```
 
-# Launch LIBERO-Object evals
-python experiments/robot/libero/run_libero_eval.py \
+#### LIBERO-Object
+
+```bash
+cd $OPENVLA_REPO
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --model_family openvla \
-  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-object \
+  --pretrained_checkpoint $WORK_ROOT/models/openvla-7b-finetuned-libero-object \
   --task_suite_name libero_object \
   --center_crop True
+```
 
-# Launch LIBERO-Goal evals
-python experiments/robot/libero/run_libero_eval.py \
+#### LIBERO-Goal
+
+```bash
+cd $OPENVLA_REPO
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --model_family openvla \
-  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-goal \
+  --pretrained_checkpoint $WORK_ROOT/models/openvla-7b-finetuned-libero-goal \
   --task_suite_name libero_goal \
   --center_crop True
+```
 
-# Launch LIBERO-10 (LIBERO-Long) evals
-python experiments/robot/libero/run_libero_eval.py \
+#### LIBERO-10（LIBERO-Long）
+
+```bash
+cd $OPENVLA_REPO
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
   --model_family openvla \
-  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-10 \
+  --pretrained_checkpoint $WORK_ROOT/models/openvla-7b-finetuned-libero-10 \
   --task_suite_name libero_10 \
   --center_crop True
 ```
 
-Notes:
-* The evaluation script will run 500 trials by default (10 tasks x 50 episodes each). You can modify the number of
-  trials per task by setting `--num_trials_per_task`. You can also change the random seed via `--seed`.
-* **NOTE: Setting `--center_crop True` is important** because we fine-tuned OpenVLA with random crop augmentations
-  (we took a random crop with 90% area in every training sample, so at test time we simply take the center 90% crop).
-* The evaluation script logs results locally. You can also log results in Weights & Biases
-  by setting `--use_wandb True` and specifying `--wandb_project <PROJECT>` and `--wandb_entity <ENTITY>`.
-* The results reported in our paper were obtained using **Python 3.10.13, PyTorch 2.2.0, transformers 4.40.1, and
-  flash-attn 2.5.5** on an **NVIDIA A100 GPU**, averaged over three random seeds. Please stick to these package versions.
-  Note that results may vary slightly if you use a different GPU for evaluation due to GPU nondeterminism in large models
-  (though we have tested that results were consistent across different machines with A100 GPUs).
-
-Please file a GitHub Issue if you run into any problems.
+> 作用说明：  
+> - `--center_crop True` 非常重要，官方 LIBERO 微调时使用过随机裁剪增强，推理时要做中心裁剪对齐分布。  
+> - 默认 `10 tasks x 50 episodes = 500` 次 rollout，耗时较长。
 
 ---
 
-## Repository Structure
+## 8. 推理过程中每一步在做什么（机制解释）
 
-High-level overview of repository/project file-tree:
+下面对应 `experiments/robot/libero/run_libero_eval.py` 的主流程：
 
-+ `prismatic` - Package source; provides core utilities for model loading, training, data preprocessing, etc.
-+ `vla-scripts/` - Core scripts for training, fine-tuning, and deploying VLAs.
-+ `experiments/` - Code for evaluating OpenVLA policies in robot environments.
-+ `LICENSE` - All code is made available under the MIT License; happy hacking!
-+ `Makefile` - Top-level Makefile (by default, supports linting - checking & auto-fix); extend as needed.
-+ `pyproject.toml` - Full project configuration details (including dependencies), as well as tool configurations.
-+ `README.md` - You are here!
+1. 读取配置与随机种子  
+   作用：保证实验可复现（同一 seed 下结果波动更可控）。
+
+2. 加载 OpenVLA 模型和 Processor  
+   作用：把图像+文本 prompt 编码成模型输入，再生成动作 token。
+
+3. 根据任务套件设置 `unnorm_key`  
+   作用：把模型输出的归一化动作反归一化回该任务数据分布范围。
+
+4. 初始化 LIBERO 环境与任务描述  
+   作用：逐任务进行模拟，任务文本会注入提示词中。
+
+5. 每回合开始先空转若干步（`num_steps_wait`）  
+   作用：等待环境中物体稳定下落，减少初始抖动影响。
+
+6. 取图像，必要时做中心裁剪，拼接 prompt  
+   作用：让输入分布接近训练时分布，提高成功率。
+
+7. `predict_action()` 输出 7 维动作  
+   作用：得到末端位姿增量+夹爪开合控制。
+
+8. 夹爪动作规范化 + 符号翻转  
+   作用：适配 LIBERO 环境动作定义，避免“动作看似合理但执行方向反了”。
+
+9. 环境 `step(action)` 执行并判断 done/success  
+   作用：产生奖励、终止信号与下一帧观测。
+
+10. 保存回放视频与日志  
+    作用：便于可视化审查失败样本和统计汇报。
 
 ---
 
+## 9. 模型架构（初学者可读版）
 
-# VLA Performance Troubleshooting
+### 9.1 OpenVLA 是什么
 
-In this section we cover best practices for debugging poor VLA performance after fine-tuning on your target domain robot dataset.
+OpenVLA 是 Vision-Language-Action（视觉-语言-动作）模型。  
+它把“图像 + 指令文本”映射成“机器人动作”。
 
-**Note**: OpenVLA typically requires fine-tuning on a small demonstration dataset (~100 demos) from your target domain robot. Out-of-the-box, it only works well on domains from the training dataset.
+### 9.2 核心结构（结合官方说明）
 
-**Sanity checks**:
-- replay the actions from a demonstration from your fine-tuning dataset and make sure that the robot can execute the task successfully (this ensures that your data collection pipeline is correct)
-- once you fine-tuned a model, load the model in your inference pipeline (as if you would run it to control the robot), but feed images from the fine-tuning dataset into the model (pretending they come from the robot) and verify that you can reproduce the token accuracies / L1 errors from training (this ensures that your inference pipeline is correct)
+1. 视觉编码器（Vision Backbone）  
+   OpenVLA-7B 使用 Prismatic 的 `prism-dinosiglip-224px` 路线，融合 DINOv2 + SigLIP 视觉特征。
 
-**Best practices for fine-tuning data collection**:
-If your setup passed the above two sanity checks, the issue may not be in model training, but in the data you fine-tuned the model with. Some best practices for data collection:
-- *Collect at a control frequency around 5-10Hz.* OpenVLA is not trained with action chunking, empirically the model struggles with high-frequency data. If your robot setup uses a high-frequency controller (eg 50 Hz), consider downsampling your actions to 5Hz. Verify first that your robot can still solve the task when using 5Hz actions (ie repeat sanity check (1) above with 5Hz actions)
-- *Avoid pauses / small actions during data collection.* Because OpenVLA is trained without action chunking, the model can be sensitive to idle actions in the fine-tuning data. If your data contains steps in which the robot barely moves, the model may "get stuck" in these steps at inference time. Try to collect fine-tuning demonstrations with continuous, slow movement.
-- *Ensure sufficient data coverage.* If you plan to test the model with some variation, e.g. different initial positions of objects, make sure that your fine-tuning data contains sufficient diversity of such conditions as well, e.g. shows demonstrations with diverse initial conditions.
-- *Use consistent task strategies during data collection.* This is not a hard constraint, but may make your life easier. Try to demonstrate tasks in consistent ways, e.g. approach objects from the same side, perform sub-steps in the same order even if they could be performed in arbitrary sequences. Being consistent gives you a less multi-modal fine-tuning dataset, which makes the modeling problem easier.
+2. 语言模型骨干（LLM）  
+   基于 Llama-2 系列语言模型结构作为动作生成主干。
 
+3. 动作离散化（Action Tokenization）  
+   连续动作会离散到 `256` 个 bin（代码中 `n_action_bins=256`），并映射到词表尾部 token，模型以“生成 token”的方式输出动作。
+
+4. 动作反归一化（Unnormalization）  
+   生成的是标准化动作，推理时依赖 `norm_stats`（如 `q01/q99`）恢复到真实动作量纲。
+
+### 9.3 为什么这样设计
+
+1. 可复用大模型生态：把机器人控制转成“序列生成”问题，可直接利用 HF + LLM 训练推理工具链。
+2. 文本任务泛化更强：任务以自然语言描述，跨任务迁移更方便。
+3. 统一接口：相机图像 + 文本进，动作出，和真实机器人部署接口一致。
 
 ---
 
-#### Citation
+## 10. 推理与结果读取
 
-If you find our code or models useful in your work, please cite [our paper](https://arxiv.org/abs/2406.09246):
+### 10.1 日志与视频位置
 
-```bibtex
-@article{kim24openvla,
-    title={OpenVLA: An Open-Source Vision-Language-Action Model},
-    author={{Moo Jin} Kim and Karl Pertsch and Siddharth Karamcheti and Ted Xiao and Ashwin Balakrishna and Suraj Nair and Rafael Rafailov and Ethan Foster and Grace Lam and Pannag Sanketi and Quan Vuong and Thomas Kollar and Benjamin Burchfiel and Russ Tedrake and Dorsa Sadigh and Sergey Levine and Percy Liang and Chelsea Finn},
-    journal = {arXiv preprint arXiv:2406.09246},
-    year={2024}
-} 
+- 日志文件：`$OPENVLA_REPO/experiments/logs/*.txt`
+- 回放视频：`$OPENVLA_REPO/rollouts/<date>/*.mp4`
+
+### 10.2 查看实时进度
+
+```bash
+tail -f $OPENVLA_REPO/experiments/logs/EVAL-libero_spatial-openvla-*.txt
 ```
+
+### 10.3 本机当前已观测到的实际结果样例
+
+在 `EVAL-libero_spatial-openvla-2026_04_07-23_13_27.txt` 中，中途统计到：
+
+- `# episodes completed so far: 177`
+- `# successes: 152 (85.9%)`
+
+说明：
+
+1. 这是中途结果，不是最终 500 rollout 终值。
+2. 该中途值已接近官方报告量级（Spatial 官方均值约 `84.7% ± 0.9%`）。
+3. 最终结论应以完整 500 回合结果为准。
+
+---
+
+## 11. 常见问题与补救（按实际高频问题整理）
+
+### 11.1 `ModuleNotFoundError: No module named 'torch'`
+
+原因：命令没走 `openvla` 环境的 Python。  
+修复：
+
+```bash
+which python
+/mnt/data/home/yqy/miniforge3/envs/openvla/bin/python -c "import torch; print(torch.__version__)"
+```
+
+统一用：
+
+```bash
+export OPENVLA_PY=/mnt/data/home/yqy/miniforge3/envs/openvla/bin/python
+```
+
+### 11.2 卡在 `[*] Loading in BF16 with Flash-Attention Enabled`
+
+常见原因：
+
+1. 正在首次下载大模型分片（不是死机）。
+2. 网络或代理不稳定导致下载无速度。
+
+排查：
+
+```bash
+watch -n 10 "date '+%F %T'; ls -lh $WORK_ROOT/models/openvla-7b-finetuned-libero-spatial/.cache/huggingface/download | tail -n 5"
+```
+
+### 11.3 `hf_transfer` 报错 / CAS 链路报错
+
+典型报错：`RuntimeError: An error occurred while downloading using hf_transfer`  
+修复：
+
+```bash
+export HF_HUB_ENABLE_HF_TRANSFER=0
+export HF_HUB_DISABLE_XET=1
+```
+
+然后重试下载命令，自动断点续传。
+
+### 11.4 SSL 报错 `UNEXPECTED_EOF_WHILE_READING`
+
+原因：代理链路不稳或 TLS 中断。  
+修复建议：
+
+1. 先确认代理端口可用（`127.0.0.1:7897`）。
+2. 切换更稳定网络后重试。
+3. 临时取消代理做对比测试。
+
+### 11.5 `Address already in use`
+
+原因：端口被占用。  
+修复：
+
+```bash
+lsof -i :8016
+kill -9 <PID>
+```
+
+或直接换端口。
+
+### 11.6 TensorFlow / Gym / robosuite Warning 很多
+
+以下通常不是致命错误：
+
+1. TensorFlow oneDNN/cuDNN 注册 warning
+2. Gym unmaintained 提示
+3. robosuite 宏文件 warning
+
+只要脚本继续推进 episode 并输出成功率，通常可忽略这些 warning。
+
+### 11.7 下载到 0% 很久不动
+
+先确认不是刚建立连接。若长时间 0B/s：
+
+1. 换代理节点
+2. 关闭 `HF_HUB_ENABLE_HF_TRANSFER`
+3. 保留 `HF_HOME` 固定缓存，重复执行同一下载命令进行续传
+
+---
+
+## 12. 官方数据集说明（和你当前复现的关系）
+
+1. 跑官方 `run_libero_eval.py` 评测，核心依赖是 LIBERO 环境、任务定义和官方 checkpoint。
+2. OpenVLA README 中提到的 `modified_libero_rlds`（约 10GB）主要用于微调训练，不是评测必须。
+
+可选下载命令：
+
+```bash
+cd $WORK_ROOT
+git clone https://huggingface.co/datasets/openvla/modified_libero_rlds
+```
+
+> 作用说明：当你后续要做“再训练/微调”时，这份 RLDS 数据才是关键。
+
+---
+
+## 13. 一键核对清单（执行前后自检）
+
+### 13.1 执行前
+
+1. `nvidia-smi` 正常
+2. `openvla` conda 环境可用
+3. `python -c "import torch; print(torch.cuda.is_available())"` 为 `True`
+4. LIBERO config 文件存在
+5. checkpoint 分片完整
+
+### 13.2 执行后
+
+1. 日志文件生成在 `experiments/logs/`
+2. `rollouts/` 下生成 mp4
+3. 日志中持续出现 `# successes: ...`
+4. 完整 500 rollout 结束后有稳定总成功率
+
+---
+
+## 14. 推荐复现实验顺序（节省时间）
+
+1. 先下载 `libero_spatial` checkpoint，跑 smoke test（1 trial/task）。
+2. 再跑 `libero_spatial` 全量 500 rollout，确认链路稳定。
+3. 按同样流程跑 `object -> goal -> libero_10`。
+4. 最后统一汇总四套结果。
+
+---
+
+## 15. 参考入口（仓库内）
+
+1. 官方 LIBERO 评测脚本：`experiments/robot/libero/run_libero_eval.py`
+2. OpenVLA 推理工具：`experiments/robot/openvla_utils.py`
+3. 机器人评测公共函数：`experiments/robot/robot_utils.py`
+4. 动作离散器（256 bins）：`prismatic/vla/action_tokenizer.py`
+
+---
+
+## 16. 总结
+
+在 `Ubuntu 20.04 + RTX A5000` 上，本流程已经可以打通：
+
+1. OpenVLA 本地加载与 GPU 推理
+2. LIBERO 官方四套任务的标准评测入口
+3. 日志与视频证据链输出
+4. 常见网络/依赖/端口错误的可执行补救方案
+
+如果你接下来要从“仿真复现”走向“真实 Airbot 部署”，建议下一步做三件事：
+
+1. 先固定相机内参与图像预处理流程，保证输入分布一致。
+2. 用少量真机示教做 LoRA 微调到 Airbot 任务域。
+3. 用当前同一套推理接口（图像+文本->动作）接入真实控制栈，逐步放开速度与动作范围。
+

--- a/docs/VALID_COMMANDS.md
+++ b/docs/VALID_COMMANDS.md
@@ -1,0 +1,263 @@
+# OpenVLA（A5000 + Ubuntu 20.04）已验证命令清单
+
+## 0) 基础路径与 Conda 路径
+
+```bash
+export WORK_ROOT=/mnt/data/home/yqy/YANGCHENX/openvla_sim
+export OPENVLA_REPO=$WORK_ROOT/openvla
+export MODEL_DIR=$WORK_ROOT/models/openvla-7b
+export PATH=/mnt/data/home/yqy/miniforge3/bin:$PATH
+export OPENVLA_PY=/mnt/data/home/yqy/miniforge3/envs/openvla/bin/python
+```
+
+## 1) 创建工作目录并克隆官方仓库
+
+```bash
+mkdir -p $WORK_ROOT
+cd $WORK_ROOT
+git clone https://github.com/openvla/openvla.git
+```
+
+## 2) 创建 Python 3.10 环境
+
+```bash
+conda create -n openvla python=3.10 -y
+```
+
+## 3) 安装核心依赖（GPU 推理）
+
+```bash
+conda run -n openvla pip install torch==2.2.0 torchvision==0.17.0 torchaudio==2.2.0 --index-url https://download.pytorch.org/whl/cu121
+conda run -n openvla pip install "numpy<2"
+cd $OPENVLA_REPO
+conda run -n openvla pip install -r requirements-min.txt
+conda run -n openvla pip install draccus==0.8.0 json-numpy fastapi uvicorn pillow accelerate==0.30.1 peft==0.11.1 einops sentencepiece==0.1.99
+conda run -n openvla pip install packaging ninja
+conda run -n openvla pip install "https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.5/flash_attn-2.5.5+cu122torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl"
+cd $OPENVLA_REPO
+conda run -n openvla pip install -e . --no-deps
+```
+
+## 4) 本地下载 OpenVLA-7B 权重
+
+```bash
+mkdir -p $MODEL_DIR
+conda run -n openvla huggingface-cli download openvla/openvla-7b --local-dir $MODEL_DIR
+```
+
+## 5) 校验本地模型文件
+
+```bash
+ls -lah $MODEL_DIR/model-*.safetensors
+python3 - <<'PY'
+import os, glob, json
+base="/mnt/data/home/yqy/YANGCHENX/openvla_sim/models/openvla-7b"
+files=sorted(glob.glob(base+"/model-*-of-*.safetensors"))
+print("num_shards", len(files))
+print("sum_bytes", sum(os.path.getsize(f) for f in files))
+with open(base+"/model.safetensors.index.json") as f:
+    print("index_total_size", json.load(f)["metadata"]["total_size"])
+PY
+```
+
+## 6) 本地推理连通性检查（已验证）
+
+```bash
+conda run --no-capture-output -n openvla python - <<'PY'
+from transformers import AutoModelForVision2Seq, AutoProcessor
+from PIL import Image
+import numpy as np
+import torch
+
+model_path = "/mnt/data/home/yqy/YANGCHENX/openvla_sim/models/openvla-7b"
+processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+vla = AutoModelForVision2Seq.from_pretrained(
+    model_path,
+    attn_implementation="flash_attention_2",
+    torch_dtype=torch.bfloat16,
+    low_cpu_mem_usage=True,
+    trust_remote_code=True,
+).to("cuda:0")
+
+image = Image.fromarray(np.zeros((224, 224, 3), dtype=np.uint8))
+prompt = "In: What action should the robot take to pick up the block?\nOut:"
+inputs = processor(prompt, image).to("cuda:0", dtype=torch.bfloat16)
+action = vla.predict_action(**inputs, unnorm_key="bridge_orig", do_sample=False)
+print("ok_action_shape", np.array(action).shape)
+print("ok_action", action)
+PY
+```
+
+## 7) 启动 REST 服务（已验证）
+
+```bash
+cd $OPENVLA_REPO
+conda run --no-capture-output -n openvla python vla-scripts/deploy.py \
+  --openvla_path $MODEL_DIR \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+## 8) 客户端请求测试（已验证）
+
+```bash
+conda run --no-capture-output -n openvla python - <<'PY'
+import numpy as np
+import requests
+import json_numpy
+json_numpy.patch()
+
+payload = {
+    "image": np.zeros((224, 224, 3), dtype=np.uint8),
+    "instruction": "pick up the block",
+    "unnorm_key": "bridge_orig",
+}
+r = requests.post("http://127.0.0.1:8000/act", json=payload, timeout=120)
+print("status", r.status_code)
+print("resp", r.text)
+PY
+```
+
+## 9) 常用诊断命令
+
+```bash
+nvidia-smi
+conda run -n openvla python -c "import torch; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+## 10) MuJoCo 仿真页面可视化（已验证）
+
+```bash
+# 首次使用需要安装 MuJoCo 依赖
+$OPENVLA_PY -m pip install "gymnasium[mujoco]==0.29.1"
+
+# 启动 OpenVLA + MuJoCo 网页可视化闭环
+cd $OPENVLA_REPO
+$OPENVLA_PY vla-scripts/mujoco_openvla_viz.py \
+  --openvla_path $MODEL_DIR \
+  --env_id Reacher-v4 \
+  --ctrl_scale 30 \
+  --do_sample \
+  --host 127.0.0.1 \
+  --port 8012
+```
+
+打开浏览器访问：
+
+```text
+http://127.0.0.1:8012
+```
+
+可选调试（确认不是黑屏/静帧）：
+
+```bash
+curl -s http://127.0.0.1:8012/state | python -m json.tool
+```
+
+如果遇到 `ModuleNotFoundError: torch`，先执行：
+
+```bash
+$OPENVLA_PY -c "import sys, torch; print(sys.executable); print(torch.__version__)"
+```
+
+## 11) 官方 LIBERO 基准复现（OpenVLA README 对应流程）
+
+### 11.1 克隆并安装 LIBERO（官方）
+
+```bash
+export LIBERO_ROOT=$WORK_ROOT/LIBERO
+git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git $LIBERO_ROOT
+cd $LIBERO_ROOT
+$OPENVLA_PY -m pip install -e . --config-settings editable_mode=compat
+```
+
+### 11.2 安装 LIBERO 评测所需依赖（官方 + 运行补齐）
+
+```bash
+cd $OPENVLA_REPO
+$OPENVLA_PY -m pip install -r experiments/robot/libero/libero_requirements.txt
+$OPENVLA_PY -m pip install wandb
+$OPENVLA_PY -m pip install jsonlines matplotlib rich tensorflow==2.15.0 tensorflow_datasets==4.9.3 tensorflow_graphics==2021.12.3 "dlimp @ git+https://github.com/moojink/dlimp_openvla"
+$OPENVLA_PY -m pip install "numpy<2" "opencv-python<4.12"
+```
+
+### 11.3 预置 LIBERO 配置（避免首次 import 交互提问）
+
+```bash
+mkdir -p /mnt/data/home/yqy/.libero
+cat > /mnt/data/home/yqy/.libero/config.yaml <<'YAML'
+benchmark_root: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero
+bddl_files: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./bddl_files
+init_states: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./init_files
+datasets: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/../datasets
+assets: /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/libero/libero/./assets
+YAML
+mkdir -p /mnt/data/home/yqy/YANGCHENX/openvla_sim/LIBERO/datasets
+```
+
+### 11.4 官方评测脚本连通性检查
+
+```bash
+cd $OPENVLA_REPO
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py --help
+```
+
+### 11.5 官方 checkpoint 复现（四套任务）
+
+> 说明：以下是 OpenVLA README 中对应命令；会自动下载 checkpoint。  
+> 默认每套是 10 任务 × 每任务 50 次（共 500 rollouts），耗时较长。
+
+```bash
+cd $OPENVLA_REPO
+export HF_HOME=$WORK_ROOT/.hf_cache
+
+# LIBERO-Spatial
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-spatial \
+  --task_suite_name libero_spatial \
+  --center_crop True
+
+# LIBERO-Object
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-object \
+  --task_suite_name libero_object \
+  --center_crop True
+
+# LIBERO-Goal
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-goal \
+  --task_suite_name libero_goal \
+  --center_crop True
+
+# LIBERO-10
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-10 \
+  --task_suite_name libero_10 \
+  --center_crop True
+```
+
+### 11.6 快速 smoke test（先小规模确认可跑）
+
+```bash
+cd $OPENVLA_REPO
+export HF_HOME=$WORK_ROOT/.hf_cache
+$OPENVLA_PY experiments/robot/libero/run_libero_eval.py \
+  --model_family openvla \
+  --pretrained_checkpoint openvla/openvla-7b-finetuned-libero-spatial \
+  --task_suite_name libero_spatial \
+  --center_crop True \
+  --num_trials_per_task 1 \
+  --use_wandb False \
+  --seed 7 \
+  --run_id_note smoke_spatial
+```
+
+### 11.7 评测日志位置
+
+```bash
+ls -lah $OPENVLA_REPO/experiments/logs
+```

--- a/vla-scripts/deploy.py
+++ b/vla-scripts/deploy.py
@@ -83,10 +83,17 @@ class OpenVLAServer:
             trust_remote_code=True,
         ).to(self.device)
 
-        # [Hacky] Load Dataset Statistics from Disk (if passing a path to a fine-tuned model)
+        # [Hacky] Load Dataset Statistics from Disk (if passing a path to a fine-tuned model).
+        # For base HF checkpoints mirrored to a local directory, this file may not exist.
         if os.path.isdir(self.openvla_path):
-            with open(Path(self.openvla_path) / "dataset_statistics.json", "r") as f:
-                self.vla.norm_stats = json.load(f)
+            stats_path = Path(self.openvla_path) / "dataset_statistics.json"
+            if stats_path.exists():
+                with open(stats_path, "r") as f:
+                    self.vla.norm_stats = json.load(f)
+            else:
+                logging.warning(
+                    "No dataset_statistics.json found at %s; use `unnorm_key` in requests when needed.", stats_path
+                )
 
     def predict_action(self, payload: Dict[str, Any]) -> str:
         try:

--- a/vla-scripts/mujoco_openvla_viz.py
+++ b/vla-scripts/mujoco_openvla_viz.py
@@ -1,0 +1,394 @@
+"""
+mujoco_openvla_viz.py
+
+MuJoCo + OpenVLA closed-loop simulation web visualizer.
+
+Pipeline:
+  RGB frame (MuJoCo env) -> OpenVLA action (7D) -> mapped env action -> env.step()
+
+This script is intended for algorithm validation before real robot deployment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Optional
+
+# Use EGL offscreen rendering by default to avoid GUI-context crashes in server mode.
+os.environ.setdefault("MUJOCO_GL", "egl")
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+
+import gymnasium as gym
+import numpy as np
+import torch
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+from PIL import Image
+from pydantic import BaseModel
+from transformers import AutoModelForVision2Seq, AutoProcessor
+
+
+def get_openvla_prompt(instruction: str, openvla_path: str) -> str:
+    if "v01" in openvla_path:
+        system_prompt = (
+            "A chat between a curious user and an artificial intelligence assistant. "
+            "The assistant gives helpful, detailed, and polite answers to the user's questions."
+        )
+        return f"{system_prompt} USER: What action should the robot take to {instruction.lower()}? ASSISTANT:"
+    return f"In: What action should the robot take to {instruction.lower()}?\nOut:"
+
+
+class InstructionBody(BaseModel):
+    instruction: str
+
+
+@dataclass
+class Config:
+    openvla_path: str
+    unnorm_key: str
+    env_id: str
+    attn_implementation: str
+    hz: float
+    ctrl_scale: float
+    do_sample: bool
+    temperature: float
+    top_p: float
+    host: str
+    port: int
+
+
+class MujocoOpenVLAService:
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        if self.device.type != "cuda":
+            raise RuntimeError("CUDA is required for OpenVLA inference.")
+
+        self.processor = AutoProcessor.from_pretrained(cfg.openvla_path, trust_remote_code=True)
+        self.vla = AutoModelForVision2Seq.from_pretrained(
+            cfg.openvla_path,
+            attn_implementation=cfg.attn_implementation,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            trust_remote_code=True,
+        ).to(self.device)
+
+        # NOTE: Create MuJoCo env in the worker thread to avoid GL-context issues
+        # (black frames when context is created in one thread and rendered in another).
+        self.env = None
+        self.obs = None
+
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+
+        self._frame_jpeg = b""
+        self._instruction = "move end-effector towards the target"
+        self._last_openvla_action = np.zeros(7, dtype=np.float32)
+        self._last_env_action = np.zeros(1, dtype=np.float32)
+        self._last_reward = 0.0
+        self._step = 0
+        self._episode = 0
+        self._last_error = ""
+        self._prev_openvla_action: Optional[np.ndarray] = None
+        self._prev_frame: Optional[np.ndarray] = None
+        self._frame_min = 0
+        self._frame_max = 0
+        self._frame_mean = 0.0
+        self._frame_std = 0.0
+        self._frame_delta_mean = 0.0
+        self._action_delta_l2 = 0.0
+
+    def _make_env(self, env_id: str):
+        tried = []
+        for name in [env_id, "Reacher-v4", "HalfCheetah-v4"]:
+            if name in tried:
+                continue
+            tried.append(name)
+            try:
+                return gym.make(name, render_mode="rgb_array")
+            except Exception:
+                continue
+        raise RuntimeError(f"Failed to create MuJoCo env. Tried: {tried}")
+
+    def _predict_openvla(self, frame_rgb: np.ndarray, instruction: str) -> np.ndarray:
+        prompt = get_openvla_prompt(instruction, self.cfg.openvla_path)
+        image = Image.fromarray(frame_rgb.astype(np.uint8)).convert("RGB")
+        inputs = self.processor(prompt, image).to(self.device, dtype=torch.bfloat16)
+        action = self.vla.predict_action(
+            **inputs,
+            unnorm_key=self.cfg.unnorm_key,
+            do_sample=self.cfg.do_sample,
+            temperature=self.cfg.temperature,
+            top_p=self.cfg.top_p,
+        )
+        return np.asarray(action, dtype=np.float32)
+
+    def _map_to_env_action(self, openvla_action: np.ndarray) -> np.ndarray:
+        if self.env is None:
+            raise RuntimeError("Environment is not initialized yet.")
+        # Map 7D OpenVLA action to arbitrary MuJoCo action dims.
+        target_dim = int(np.prod(self.env.action_space.shape))
+        src = openvla_action.reshape(-1)
+        if target_dim <= src.shape[0]:
+            raw = src[:target_dim]
+        else:
+            reps = int(np.ceil(target_dim / src.shape[0]))
+            raw = np.tile(src, reps)[:target_dim]
+
+        # Normalize and scale for stable control.
+        normalized = np.tanh(raw) * self.cfg.ctrl_scale
+        low = self.env.action_space.low.reshape(-1)
+        high = self.env.action_space.high.reshape(-1)
+        if np.all(np.isfinite(low)) and np.all(np.isfinite(high)):
+            mid = 0.5 * (low + high)
+            half = 0.5 * (high - low)
+            out = mid + np.clip(normalized, -1.0, 1.0) * half
+        else:
+            out = normalized
+        return out.astype(np.float32)
+
+    def _encode_jpeg(self, frame_rgb: np.ndarray) -> bytes:
+        img = Image.fromarray(frame_rgb.astype(np.uint8))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        return buf.getvalue()
+
+    def _loop(self) -> None:
+        self.env = self._make_env(self.cfg.env_id)
+        self.obs, _ = self.env.reset(seed=0)
+        _ = self.env.render()  # warmup renderer
+        with self._lock:
+            self._last_env_action = np.zeros(int(np.prod(self.env.action_space.shape)), dtype=np.float32)
+
+        period = 1.0 / self.cfg.hz
+        while self._running:
+            t0 = time.time()
+            try:
+                with self._lock:
+                    instruction = self._instruction
+
+                infer_frame = self.env.render()
+                if infer_frame is None:
+                    raise RuntimeError("MuJoCo render() returned None.")
+
+                openvla_action = self._predict_openvla(infer_frame, instruction)
+                env_action = self._map_to_env_action(openvla_action)
+                self.obs, reward, terminated, truncated, _ = self.env.step(env_action)
+                if terminated or truncated:
+                    self.obs, _ = self.env.reset()
+                    self._episode += 1
+                display_frame = self.env.render()
+                if display_frame is None:
+                    display_frame = infer_frame
+
+                # Runtime diagnostics for "black screen" / "static frame" debugging.
+                frame_min = int(display_frame.min())
+                frame_max = int(display_frame.max())
+                frame_mean = float(display_frame.mean())
+                frame_std = float(display_frame.std())
+                if self._prev_frame is None:
+                    frame_delta_mean = 0.0
+                else:
+                    frame_delta_mean = float(
+                        np.mean(
+                            np.abs(display_frame.astype(np.float32) - self._prev_frame.astype(np.float32))
+                        )
+                    )
+                if self._prev_openvla_action is None:
+                    action_delta_l2 = 0.0
+                else:
+                    action_delta_l2 = float(np.linalg.norm(openvla_action - self._prev_openvla_action))
+
+                self._prev_frame = display_frame.copy()
+                self._prev_openvla_action = openvla_action.copy()
+
+                with self._lock:
+                    self._frame_jpeg = self._encode_jpeg(display_frame)
+                    self._last_openvla_action = openvla_action
+                    self._last_env_action = env_action
+                    self._last_reward = float(reward)
+                    self._frame_min = frame_min
+                    self._frame_max = frame_max
+                    self._frame_mean = frame_mean
+                    self._frame_std = frame_std
+                    self._frame_delta_mean = frame_delta_mean
+                    self._action_delta_l2 = action_delta_l2
+                    self._step += 1
+                    self._last_error = ""
+            except Exception as exc:  # noqa: BLE001
+                with self._lock:
+                    self._last_error = str(exc)
+                time.sleep(0.5)
+                continue
+
+            elapsed = time.time() - t0
+            if elapsed < period:
+                time.sleep(period - elapsed)
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self.env is not None:
+            self.env.close()
+
+    def build_app(self) -> FastAPI:
+        @asynccontextmanager
+        async def lifespan(_: FastAPI):
+            self.start()
+            yield
+            self.stop()
+
+        app = FastAPI(title="MuJoCo OpenVLA Visualizer", lifespan=lifespan)
+
+        @app.get("/", response_class=HTMLResponse)
+        def index() -> str:
+            return """<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MuJoCo + OpenVLA</title>
+    <style>
+      body { font-family: Arial, sans-serif; background: #111; color: #eee; margin: 20px; }
+      .card { background: #1b1b1b; border: 1px solid #333; border-radius: 10px; padding: 12px; }
+      .row { display: flex; gap: 16px; align-items: flex-start; }
+      input { width: 440px; background: #222; color: #fff; border: 1px solid #666; border-radius: 6px; padding: 8px; }
+      button { margin-left: 8px; padding: 8px 12px; background: #2f2f2f; color: #fff; border: 1px solid #666; border-radius: 6px; cursor: pointer; }
+      #frame { width: 640px; max-width: 92vw; border: 1px solid #333; border-radius: 8px; }
+      pre { white-space: pre-wrap; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <h2>MuJoCo + OpenVLA 仿真闭环</h2>
+    <div class="card" style="margin-bottom:12px;">
+      <input id="instruction" value="move end-effector towards the target" />
+      <button onclick="setInstruction()">更新指令</button>
+    </div>
+    <div class="row">
+      <div class="card"><img id="frame" src="/frame.jpg" /></div>
+      <div class="card" style="min-width: 360px;"><pre id="state"></pre></div>
+    </div>
+    <script>
+      async function setInstruction() {
+        const instruction = document.getElementById('instruction').value;
+        await fetch('/instruction', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({instruction})
+        });
+      }
+      async function refresh() {
+        document.getElementById('frame').src = '/frame.jpg?t=' + Date.now();
+        const r = await fetch('/state');
+        const j = await r.json();
+        document.getElementById('state').textContent = JSON.stringify(j, null, 2);
+      }
+      setInterval(refresh, 300);
+      refresh();
+    </script>
+  </body>
+</html>"""
+
+        @app.get("/frame.jpg")
+        def frame() -> Response:
+            with self._lock:
+                data = self._frame_jpeg
+            if not data:
+                black = np.zeros((480, 480, 3), dtype=np.uint8)
+                buf = io.BytesIO()
+                Image.fromarray(black).save(buf, format="JPEG", quality=80)
+                data = buf.getvalue()
+            return Response(content=data, media_type="image/jpeg")
+
+        @app.get("/state")
+        def state() -> JSONResponse:
+            with self._lock:
+                payload = {
+                    "env_id": self.cfg.env_id,
+                    "step": self._step,
+                    "episode": self._episode,
+                    "instruction": self._instruction,
+                    "openvla_action": self._last_openvla_action.tolist(),
+                    "env_action": self._last_env_action.tolist(),
+                    "last_reward": self._last_reward,
+                    "frame_min": self._frame_min,
+                    "frame_max": self._frame_max,
+                    "frame_mean": self._frame_mean,
+                    "frame_std": self._frame_std,
+                    "frame_delta_mean": self._frame_delta_mean,
+                    "action_delta_l2": self._action_delta_l2,
+                    "ctrl_scale": self.cfg.ctrl_scale,
+                    "do_sample": self.cfg.do_sample,
+                    "error": self._last_error,
+                    "device": str(self.device),
+                    "unnorm_key": self.cfg.unnorm_key,
+                }
+            return JSONResponse(payload)
+
+        @app.post("/instruction")
+        def set_instruction(body: InstructionBody) -> JSONResponse:
+            with self._lock:
+                self._instruction = body.instruction.strip()
+            return JSONResponse({"ok": True, "instruction": self._instruction})
+
+        return app
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="MuJoCo + OpenVLA web visualizer")
+    parser.add_argument("--openvla_path", type=str, required=True, help="HF path or local model dir")
+    parser.add_argument("--unnorm_key", type=str, default="bridge_orig")
+    parser.add_argument("--env_id", type=str, default="Reacher-v4")
+    parser.add_argument("--attn_implementation", type=str, default="flash_attention_2")
+    parser.add_argument("--hz", type=float, default=2.0, help="Closed-loop frequency")
+    parser.add_argument("--ctrl_scale", type=float, default=30.0, help="OpenVLA action scaling before env mapping")
+    parser.add_argument(
+        "--do_sample",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable stochastic decoding to avoid static actions on nearly-static frames.",
+    )
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--top_p", type=float, default=0.9)
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8012)
+    args = parser.parse_args()
+    return Config(
+        openvla_path=args.openvla_path,
+        unnorm_key=args.unnorm_key,
+        env_id=args.env_id,
+        attn_implementation=args.attn_implementation,
+        hz=args.hz,
+        ctrl_scale=args.ctrl_scale,
+        do_sample=args.do_sample,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        host=args.host,
+        port=args.port,
+    )
+
+
+def main() -> None:
+    cfg = parse_args()
+    service = MujocoOpenVLAService(cfg)
+    app = service.build_app()
+    uvicorn.run(app, host=cfg.host, port=cfg.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/vla-scripts/mujoco_pick_place_viz.py
+++ b/vla-scripts/mujoco_pick_place_viz.py
@@ -1,0 +1,542 @@
+"""
+mujoco_pick_place_viz.py
+
+MuJoCo FetchPickAndPlace task visualization with OpenVLA in the loop.
+
+Task:
+  Pick the cube from the table and place it at the goal marker.
+
+Control:
+  - A scripted stage controller outputs task-level target motion.
+  - OpenVLA predicts 7D action from (image, language instruction).
+  - Final control blends scripted motion with OpenVLA offsets.
+  - Optional virtual grasp mode attaches the cube when grasp stage is reached
+    to provide a stable and clear pick/place visualization loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Optional
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+
+import gymnasium as gym
+import gymnasium_robotics
+import numpy as np
+import torch
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+from PIL import Image
+from pydantic import BaseModel
+from transformers import AutoModelForVision2Seq, AutoProcessor
+
+
+def get_openvla_prompt(instruction: str, openvla_path: str) -> str:
+    if "v01" in openvla_path:
+        system_prompt = (
+            "A chat between a curious user and an artificial intelligence assistant. "
+            "The assistant gives helpful, detailed, and polite answers to the user's questions."
+        )
+        return f"{system_prompt} USER: What action should the robot take to {instruction.lower()}? ASSISTANT:"
+    return f"In: What action should the robot take to {instruction.lower()}?\nOut:"
+
+
+class InstructionBody(BaseModel):
+    instruction: str
+
+
+@dataclass
+class Config:
+    openvla_path: str
+    unnorm_key: str
+    env_id: str
+    hz: float
+    blend_openvla: float
+    episode_steps: int
+    virtual_grasp: bool
+    disable_openvla: bool
+    do_sample: bool
+    temperature: float
+    top_p: float
+    host: str
+    port: int
+
+
+class PickPlaceService:
+    STAGE_NAMES = [
+        "approach_above_object",
+        "descend_to_grasp",
+        "close_gripper",
+        "lift_object",
+        "move_to_goal",
+        "descend_to_place",
+        "release_object",
+        "retreat",
+    ]
+
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        if self.device.type != "cuda":
+            raise RuntimeError("CUDA is required for OpenVLA inference.")
+
+        self._openvla_enabled = not cfg.disable_openvla
+        self._openvla_init_error = ""
+        self.processor = None
+        self.vla = None
+        if self._openvla_enabled:
+            try:
+                self.processor = AutoProcessor.from_pretrained(cfg.openvla_path, trust_remote_code=True)
+                self.vla = AutoModelForVision2Seq.from_pretrained(
+                    cfg.openvla_path,
+                    attn_implementation="flash_attention_2",
+                    torch_dtype=torch.bfloat16,
+                    low_cpu_mem_usage=True,
+                    trust_remote_code=True,
+                ).to(self.device)
+            except Exception as exc:  # noqa: BLE001
+                self._openvla_enabled = False
+                self._openvla_init_error = str(exc)
+
+        self.env = None
+        self.obs = None
+        self.last_info = {}
+        self.stage = 0
+        self.stage_steps = 0
+
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+
+        self._frame_jpeg = b""
+        self._instruction = "pick up the cube and place it on the goal marker"
+        self._last_openvla = np.zeros(7, dtype=np.float32)
+        self._last_script = np.zeros(4, dtype=np.float32)
+        self._last_env_action = np.zeros(4, dtype=np.float32)
+        self._last_reward = 0.0
+        self._is_success = 0.0
+        self._step = 0
+        self._episode = 0
+        self._episode_step = 0
+        self._frame_mean = 0.0
+        self._frame_delta_mean = 0.0
+        self._last_error = ""
+        self._prev_frame: Optional[np.ndarray] = None
+
+        self._attached = False
+        self._attach_offset = np.array([0.0, 0.0, -0.40], dtype=np.float32)
+
+    def _make_env(self):
+        if hasattr(gymnasium_robotics, "register_envs"):
+            gymnasium_robotics.register_envs(gym)
+        return gym.make(self.cfg.env_id, render_mode="rgb_array")
+
+    @staticmethod
+    def _parse_fetch_obs(obs_dict: dict) -> dict:
+        obs = obs_dict["observation"]
+        desired_goal = obs_dict["desired_goal"]
+        achieved_goal = obs_dict["achieved_goal"]
+        grip_pos = obs[0:3]
+        object_pos = obs[3:6]
+        object_rel = obs[6:9]
+        gripper_state = obs[9:11] if obs.shape[0] >= 11 else np.zeros(2, dtype=np.float32)
+        return {
+            "grip_pos": grip_pos,
+            "object_pos": object_pos,
+            "object_rel": object_rel,
+            "gripper_state": gripper_state,
+            "desired_goal": desired_goal,
+            "achieved_goal": achieved_goal,
+        }
+
+    def _predict_openvla(self, frame_rgb: np.ndarray, instruction: str) -> np.ndarray:
+        if not self._openvla_enabled or self.processor is None or self.vla is None:
+            return np.zeros(7, dtype=np.float32)
+        prompt = get_openvla_prompt(instruction, self.cfg.openvla_path)
+        image = Image.fromarray(frame_rgb.astype(np.uint8)).convert("RGB")
+        inputs = self.processor(prompt, image).to(self.device, dtype=torch.bfloat16)
+        action = self.vla.predict_action(
+            **inputs,
+            unnorm_key=self.cfg.unnorm_key,
+            do_sample=self.cfg.do_sample,
+            temperature=self.cfg.temperature,
+            top_p=self.cfg.top_p,
+        )
+        return np.asarray(action, dtype=np.float32)
+
+    @staticmethod
+    def _openvla_to_fetch_action(openvla_action: np.ndarray) -> np.ndarray:
+        xyz = np.tanh(openvla_action[:3] * 30.0)
+        grip = float(np.clip(openvla_action[6] * 2.0 - 1.0, -1.0, 1.0))
+        return np.array([xyz[0], xyz[1], xyz[2], grip], dtype=np.float32)
+
+    def _scripted_pick_place(self, parsed: dict, is_success: float) -> tuple[np.ndarray, float, np.ndarray]:
+        grip = parsed["grip_pos"]
+        obj = parsed["object_pos"]
+        goal = parsed["desired_goal"]
+
+        grasp = np.array([obj[0], obj[1], obj[2] + 0.40], dtype=np.float32)
+        above_obj = np.array([obj[0], obj[1], obj[2] + 0.50], dtype=np.float32)
+        carry = np.array([obj[0], obj[1], max(goal[2] + 0.53, obj[2] + 0.56)], dtype=np.float32)
+        above_goal = np.array([goal[0], goal[1], goal[2] + 0.50], dtype=np.float32)
+        place = np.array([goal[0], goal[1], goal[2] + 0.41], dtype=np.float32)
+        retreat = np.array([goal[0], goal[1], goal[2] + 0.58], dtype=np.float32)
+
+        dist_grip_above = float(np.linalg.norm(grip - above_obj))
+        dist_grip_grasp = float(np.linalg.norm(grip - grasp))
+        dist_obj_goal = float(np.linalg.norm(obj - goal))
+        dist_obj_goal_xy = float(np.linalg.norm(obj[:2] - goal[:2]))
+
+        if self.stage == 0 and dist_grip_above < 0.035:
+            self.stage, self.stage_steps = 1, 0
+        elif self.stage == 1 and dist_grip_grasp < 0.028:
+            self.stage, self.stage_steps = 2, 0
+        elif self.stage == 2 and self.stage_steps >= 10:
+            self.stage, self.stage_steps = 3, 0
+        elif self.stage == 3 and (self._attached or self.stage_steps >= 22):
+            self.stage, self.stage_steps = 4, 0
+        elif self.stage == 4 and (dist_obj_goal_xy < 0.05 or self.stage_steps >= 28):
+            self.stage, self.stage_steps = 5, 0
+        elif self.stage == 5 and (dist_obj_goal < 0.06 or self.stage_steps >= 24):
+            self.stage, self.stage_steps = 6, 0
+        elif self.stage == 6 and (is_success > 0.5 or self.stage_steps >= 10):
+            self.stage, self.stage_steps = 7, 0
+        elif self.stage == 7 and self.stage_steps >= 8:
+            self.stage, self.stage_steps = 0, 0
+        self.stage_steps += 1
+
+        if self.stage == 0:
+            target, grip_cmd = above_obj, 1.0
+        elif self.stage == 1:
+            target, grip_cmd = grasp, 1.0
+        elif self.stage == 2:
+            target, grip_cmd = grasp, -1.0
+        elif self.stage == 3:
+            target, grip_cmd = carry, -1.0
+        elif self.stage == 4:
+            target, grip_cmd = above_goal, -1.0
+        elif self.stage == 5:
+            target, grip_cmd = place, -1.0
+        elif self.stage == 6:
+            target, grip_cmd = place, 1.0
+        else:
+            target, grip_cmd = retreat, 1.0
+
+        pos_cmd = np.clip((target - grip) * 10.0, -1.0, 1.0)
+        script_action = np.array([pos_cmd[0], pos_cmd[1], pos_cmd[2], grip_cmd], dtype=np.float32)
+        return target, float(grip_cmd), script_action
+
+    def _apply_target_control(self, target: np.ndarray, grip_cmd: float) -> None:
+        uw = self.env.unwrapped
+        target_clip = np.clip(
+            target.astype(np.float32),
+            np.array([1.0, 0.30, 0.35], dtype=np.float32),
+            np.array([1.70, 1.00, 1.00], dtype=np.float32),
+        )
+        action = np.array([0.0, 0.0, 0.0, float(np.clip(grip_cmd, -1.0, 1.0))], dtype=np.float32)
+        uw._set_action(action)
+        uw.data.mocap_pos[:] = target_clip.reshape(1, 3)
+        uw._mujoco_step(action)
+        uw._step_callback()
+
+    def _maybe_virtual_grasp(self, parsed: dict, grip_cmd: float) -> None:
+        if not self.cfg.virtual_grasp:
+            return
+        uw = self.env.unwrapped
+        grip = parsed["grip_pos"]
+        obj = parsed["object_pos"]
+
+        dist_xy = float(np.linalg.norm(grip[:2] - obj[:2]))
+        dist_z = float(abs((obj[2] + 0.40) - grip[2]))
+        closing = grip_cmd < -0.2
+
+        if (not self._attached) and self.stage in (2, 3) and closing and dist_xy < 0.03 and dist_z < 0.05:
+            self._attached = True
+            self._attach_offset = (obj - grip).astype(np.float32)
+            self._attach_offset[2] = float(np.clip(self._attach_offset[2], -0.46, -0.32))
+
+        if self._attached and self.stage >= 6:
+            self._attached = False
+
+        if self._attached:
+            object_q = uw._utils.get_joint_qpos(uw.model, uw.data, "object0:joint").copy()
+            desired_obj = (grip + self._attach_offset).astype(np.float32)
+            desired_obj[2] = max(0.008, float(desired_obj[2]))
+            object_q[:3] = desired_obj
+            uw._utils.set_joint_qpos(uw.model, uw.data, "object0:joint", object_q)
+            uw._utils.set_joint_qvel(uw.model, uw.data, "object0:joint", np.zeros(6, dtype=np.float32))
+            uw._mujoco.mj_forward(uw.model, uw.data)
+
+    @staticmethod
+    def _encode_jpeg(frame: np.ndarray) -> bytes:
+        img = Image.fromarray(frame.astype(np.uint8))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        return buf.getvalue()
+
+    def _compute_reward_success(self, obs: dict) -> tuple[float, float]:
+        uw = self.env.unwrapped
+        success = float(uw._is_success(obs["achieved_goal"], uw.goal))
+        info = {"is_success": success}
+        reward = float(uw.compute_reward(obs["achieved_goal"], uw.goal, info))
+        return reward, success
+
+    def _reset_episode(self, seed: Optional[int] = None) -> None:
+        self.obs, self.last_info = self.env.reset(seed=seed)
+        self.stage = 0
+        self.stage_steps = 0
+        self._episode_step = 0
+        self._attached = False
+
+    def _loop(self) -> None:
+        self.env = self._make_env()
+        self._reset_episode(seed=0)
+        _ = self.env.render()
+
+        period = 1.0 / self.cfg.hz
+        while self._running:
+            t0 = time.time()
+            try:
+                with self._lock:
+                    instruction = self._instruction
+
+                frame = self.env.render()
+                if frame is None:
+                    raise RuntimeError("Render returned None")
+
+                parsed_before = self._parse_fetch_obs(self.obs)
+                is_success_prev = float(self.last_info.get("is_success", 0.0))
+                script_target, script_grip, script_action = self._scripted_pick_place(parsed_before, is_success_prev)
+                openvla_action = self._predict_openvla(frame, instruction)
+                openvla_fetch = self._openvla_to_fetch_action(openvla_action)
+
+                blend = float(np.clip(self.cfg.blend_openvla, 0.0, 1.0))
+                target = script_target + blend * openvla_fetch[:3] * 0.03
+                grip_cmd = float(np.clip((1.0 - blend) * script_grip + blend * openvla_fetch[3], -1.0, 1.0))
+                env_action = np.array(
+                    [float(target[0]), float(target[1]), float(target[2]), grip_cmd],
+                    dtype=np.float32,
+                )
+
+                self._apply_target_control(target, grip_cmd)
+                self.obs = self.env.unwrapped._get_obs()
+                parsed_after = self._parse_fetch_obs(self.obs)
+                self._maybe_virtual_grasp(parsed_after, grip_cmd)
+                self.obs = self.env.unwrapped._get_obs()
+                reward, is_success = self._compute_reward_success(self.obs)
+                self.last_info = {"is_success": is_success}
+
+                self._episode_step += 1
+                if self._episode_step >= self.cfg.episode_steps:
+                    self._episode += 1
+                    self._reset_episode(seed=None)
+
+                disp = self.env.render()
+                if disp is None:
+                    disp = frame
+
+                frame_mean = float(disp.mean())
+                if self._prev_frame is None:
+                    frame_delta = 0.0
+                else:
+                    frame_delta = float(np.mean(np.abs(disp.astype(np.float32) - self._prev_frame.astype(np.float32))))
+                self._prev_frame = disp.copy()
+
+                with self._lock:
+                    self._frame_jpeg = self._encode_jpeg(disp)
+                    self._last_openvla = openvla_action
+                    self._last_script = script_action
+                    self._last_env_action = env_action
+                    self._last_reward = float(reward)
+                    self._is_success = float(is_success)
+                    self._frame_mean = frame_mean
+                    self._frame_delta_mean = frame_delta
+                    self._step += 1
+                    self._last_error = ""
+            except Exception as exc:  # noqa: BLE001
+                with self._lock:
+                    self._last_error = str(exc)
+                time.sleep(0.5)
+                continue
+
+            elapsed = time.time() - t0
+            if elapsed < period:
+                time.sleep(period - elapsed)
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self.env is not None:
+            self.env.close()
+
+    def app(self) -> FastAPI:
+        @asynccontextmanager
+        async def lifespan(_: FastAPI):
+            self.start()
+            yield
+            self.stop()
+
+        app = FastAPI(title="Fetch Pick&Place + OpenVLA", lifespan=lifespan)
+
+        @app.get("/", response_class=HTMLResponse)
+        def index() -> str:
+            return """<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Fetch Pick&Place + OpenVLA</title>
+    <style>
+      body { font-family: Arial, sans-serif; background: #111; color: #eee; margin: 20px; }
+      .card { background: #1b1b1b; border: 1px solid #333; border-radius: 10px; padding: 12px; }
+      .row { display: flex; gap: 16px; align-items: flex-start; }
+      input { width: 580px; background: #222; color: #fff; border: 1px solid #666; border-radius: 6px; padding: 8px; }
+      button { margin-left: 8px; padding: 8px 12px; background: #2f2f2f; color: #fff; border: 1px solid #666; border-radius: 6px; cursor: pointer; }
+      #frame { width: 640px; max-width: 92vw; border: 1px solid #333; border-radius: 8px; }
+      pre { white-space: pre-wrap; margin: 0; }
+      .task { margin: 8px 0 14px 0; color: #8ec5ff; }
+    </style>
+  </head>
+  <body>
+    <h2>MuJoCo 抓取/放置任务可视化（FetchPickAndPlace）</h2>
+    <div class="task">任务: 抓起桌面方块并放到目标点（Pick & Place）。</div>
+    <div class="card" style="margin-bottom:12px;">
+      <input id="instruction" value="pick up the cube and place it on the goal marker" />
+      <button onclick="setInstruction()">更新指令</button>
+    </div>
+    <div class="row">
+      <div class="card"><img id="frame" src="/frame.jpg" /></div>
+      <div class="card" style="min-width: 420px;"><pre id="state"></pre></div>
+    </div>
+    <script>
+      async function setInstruction() {
+        const instruction = document.getElementById('instruction').value;
+        await fetch('/instruction', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({instruction})
+        });
+      }
+      async function refresh() {
+        document.getElementById('frame').src = '/frame.jpg?t=' + Date.now();
+        const r = await fetch('/state');
+        const j = await r.json();
+        document.getElementById('state').textContent = JSON.stringify(j, null, 2);
+      }
+      setInterval(refresh, 300);
+      refresh();
+    </script>
+  </body>
+</html>"""
+
+        @app.get("/frame.jpg")
+        def frame() -> Response:
+            with self._lock:
+                data = self._frame_jpeg
+            if not data:
+                black = np.zeros((480, 480, 3), dtype=np.uint8)
+                buf = io.BytesIO()
+                Image.fromarray(black).save(buf, format="JPEG", quality=80)
+                data = buf.getvalue()
+            return Response(content=data, media_type="image/jpeg")
+
+        @app.get("/state")
+        def state() -> JSONResponse:
+            with self._lock:
+                payload = {
+                    "task": "Pick cube and place on goal marker",
+                    "env_id": self.cfg.env_id,
+                    "step": self._step,
+                    "episode": self._episode,
+                    "episode_step": self._episode_step,
+                    "instruction": self._instruction,
+                    "stage": self.stage,
+                    "stage_name": self.STAGE_NAMES[self.stage],
+                    "virtual_grasp": self.cfg.virtual_grasp,
+                    "attached": self._attached,
+                    "is_success": self._is_success,
+                    "reward": self._last_reward,
+                    "openvla_action_7d": self._last_openvla.tolist(),
+                    "script_action_4d": self._last_script.tolist(),
+                    "control_target_xyz_grip": self._last_env_action.tolist(),
+                    "blend_openvla": self.cfg.blend_openvla,
+                    "openvla_enabled": self._openvla_enabled,
+                    "openvla_init_error": self._openvla_init_error,
+                    "frame_mean": self._frame_mean,
+                    "frame_delta_mean": self._frame_delta_mean,
+                    "do_sample": self.cfg.do_sample,
+                    "error": self._last_error,
+                }
+            return JSONResponse(payload)
+
+        @app.post("/instruction")
+        def set_instruction(body: InstructionBody) -> JSONResponse:
+            with self._lock:
+                self._instruction = body.instruction.strip()
+            return JSONResponse({"ok": True, "instruction": self._instruction})
+
+        return app
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Fetch Pick&Place + OpenVLA visualizer")
+    parser.add_argument("--openvla_path", type=str, required=True)
+    parser.add_argument("--unnorm_key", type=str, default="bridge_orig")
+    parser.add_argument("--env_id", type=str, default="FetchPickAndPlace-v3")
+    parser.add_argument("--hz", type=float, default=3.0)
+    parser.add_argument(
+        "--blend_openvla",
+        type=float,
+        default=0.10,
+        help="0 means fully scripted controller, 1 means fully OpenVLA-guided controller",
+    )
+    parser.add_argument("--episode_steps", type=int, default=220)
+    parser.add_argument("--virtual_grasp", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--disable_openvla", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--do_sample", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--top_p", type=float, default=0.9)
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8016)
+    args = parser.parse_args()
+    return Config(
+        openvla_path=args.openvla_path,
+        unnorm_key=args.unnorm_key,
+        env_id=args.env_id,
+        hz=args.hz,
+        blend_openvla=args.blend_openvla,
+        episode_steps=args.episode_steps,
+        virtual_grasp=args.virtual_grasp,
+        disable_openvla=args.disable_openvla,
+        do_sample=args.do_sample,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        host=args.host,
+        port=args.port,
+    )
+
+
+def main() -> None:
+    cfg = parse_args()
+    service = PickPlaceService(cfg)
+    uvicorn.run(service.app(), host=cfg.host, port=cfg.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/vla-scripts/sim_web_viz.py
+++ b/vla-scripts/sim_web_viz.py
@@ -1,0 +1,366 @@
+"""
+sim_web_viz.py
+
+OpenVLA + PyBullet minimal simulation web visualizer.
+
+Features:
+- Runs a simple PyBullet scene (KUKA iiwa + cube) in DIRECT mode.
+- Renders an RGB camera frame from simulation.
+- Uses OpenVLA to infer a 7D action from (instruction, image).
+- Applies translational/rotational delta action to the robot via IK.
+- Serves a lightweight web page for visualization and instruction editing.
+
+Usage:
+  conda run --no-capture-output -n openvla python vla-scripts/sim_web_viz.py \
+    --openvla_path /path/to/openvla-7b \
+    --host 127.0.0.1 \
+    --port 8010
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pybullet as p
+import pybullet_data
+import torch
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+from PIL import Image
+from pydantic import BaseModel
+from transformers import AutoModelForVision2Seq, AutoProcessor
+
+
+def get_openvla_prompt(instruction: str, openvla_path: str) -> str:
+    if "v01" in openvla_path:
+        system_prompt = (
+            "A chat between a curious user and an artificial intelligence assistant. "
+            "The assistant gives helpful, detailed, and polite answers to the user's questions."
+        )
+        return f"{system_prompt} USER: What action should the robot take to {instruction.lower()}? ASSISTANT:"
+    return f"In: What action should the robot take to {instruction.lower()}?\nOut:"
+
+
+@dataclass
+class SimConfig:
+    openvla_path: str
+    unnorm_key: str
+    attn_implementation: str
+    hz: float
+    width: int
+    height: int
+    pos_scale: float
+    rot_scale: float
+    host: str
+    port: int
+
+
+class InstructionBody(BaseModel):
+    instruction: str
+
+
+class OpenVLASimServer:
+    def __init__(self, cfg: SimConfig) -> None:
+        self.cfg = cfg
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        if self.device.type != "cuda":
+            raise RuntimeError("CUDA is required for real-time OpenVLA inference.")
+
+        self.processor = AutoProcessor.from_pretrained(cfg.openvla_path, trust_remote_code=True)
+        self.vla = AutoModelForVision2Seq.from_pretrained(
+            cfg.openvla_path,
+            attn_implementation=cfg.attn_implementation,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            trust_remote_code=True,
+        ).to(self.device)
+
+        self._lock = threading.Lock()
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+
+        self._frame_jpeg: bytes = b""
+        self._step = 0
+        self._instruction = "pick up the red cube"
+        self._last_action = np.zeros(7, dtype=np.float32)
+        self._last_error = ""
+
+        self._sim_init()
+
+    def _sim_init(self) -> None:
+        self.cid = p.connect(p.DIRECT)
+        p.setAdditionalSearchPath(pybullet_data.getDataPath())
+        p.resetSimulation()
+        p.setGravity(0, 0, -9.81)
+
+        p.loadURDF("plane.urdf")
+        p.loadURDF("table/table.urdf", [0.5, 0, -0.65], useFixedBase=True)
+        self.robot = p.loadURDF("kuka_iiwa/model.urdf", [0, 0, 0], useFixedBase=True)
+        self.ee_link = 6
+
+        # Simple target cube
+        self.cube = p.loadURDF("cube_small.urdf", [0.65, 0.0, 0.05], useFixedBase=False)
+
+        # Camera setup
+        self.view = p.computeViewMatrix(
+            cameraEyePosition=[1.1, 0.0, 0.7],
+            cameraTargetPosition=[0.45, 0.0, 0.1],
+            cameraUpVector=[0, 0, 1],
+        )
+        self.proj = p.computeProjectionMatrixFOV(
+            fov=60.0,
+            aspect=float(self.cfg.width) / float(self.cfg.height),
+            nearVal=0.02,
+            farVal=3.0,
+        )
+
+    def _render_rgb(self) -> np.ndarray:
+        _, _, rgba, _, _ = p.getCameraImage(
+            width=self.cfg.width,
+            height=self.cfg.height,
+            viewMatrix=self.view,
+            projectionMatrix=self.proj,
+            renderer=p.ER_BULLET_HARDWARE_OPENGL,
+        )
+        rgba = np.reshape(rgba, (self.cfg.height, self.cfg.width, 4))
+        rgb = rgba[:, :, :3].astype(np.uint8)
+        return rgb
+
+    def _predict_action(self, rgb: np.ndarray, instruction: str) -> np.ndarray:
+        prompt = get_openvla_prompt(instruction, self.cfg.openvla_path)
+        pil_img = Image.fromarray(rgb).convert("RGB")
+        inputs = self.processor(prompt, pil_img).to(self.device, dtype=torch.bfloat16)
+        action = self.vla.predict_action(
+            **inputs,
+            unnorm_key=self.cfg.unnorm_key,
+            do_sample=False,
+        )
+        return np.asarray(action, dtype=np.float32)
+
+    def _apply_action(self, action: np.ndarray) -> None:
+        dx, dy, dz, droll, dpitch, dyaw, _ = action.tolist()
+        cur_pos, cur_orn = p.getLinkState(self.robot, self.ee_link, computeForwardKinematics=True)[4:6]
+        cur_euler = p.getEulerFromQuaternion(cur_orn)
+
+        tgt_pos = [
+            cur_pos[0] + self.cfg.pos_scale * dx,
+            cur_pos[1] + self.cfg.pos_scale * dy,
+            max(0.02, cur_pos[2] + self.cfg.pos_scale * dz),
+        ]
+        tgt_euler = [
+            cur_euler[0] + self.cfg.rot_scale * droll,
+            cur_euler[1] + self.cfg.rot_scale * dpitch,
+            cur_euler[2] + self.cfg.rot_scale * dyaw,
+        ]
+        tgt_orn = p.getQuaternionFromEuler(tgt_euler)
+
+        joint_targets = p.calculateInverseKinematics(self.robot, self.ee_link, tgt_pos, tgt_orn)
+        for j in range(7):
+            p.setJointMotorControl2(
+                self.robot,
+                j,
+                controlMode=p.POSITION_CONTROL,
+                targetPosition=joint_targets[j],
+                force=200.0,
+            )
+
+    def _encode_frame(self, rgb: np.ndarray, action: np.ndarray, instruction: str) -> bytes:
+        # Add a small info strip for easier page-side debugging.
+        info_h = 44
+        canvas = np.zeros((rgb.shape[0] + info_h, rgb.shape[1], 3), dtype=np.uint8)
+        canvas[: rgb.shape[0]] = rgb
+        canvas[rgb.shape[0] :] = np.array([20, 20, 20], dtype=np.uint8)
+        img = Image.fromarray(canvas)
+        # Keep frame raw and send details as JSON; front-end overlays text.
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        return buf.getvalue()
+
+    def _loop(self) -> None:
+        dt = 1.0 / self.cfg.hz
+        while self._running:
+            t0 = time.time()
+            try:
+                with self._lock:
+                    instruction = self._instruction
+
+                rgb = self._render_rgb()
+                action = self._predict_action(rgb, instruction)
+                self._apply_action(action)
+                for _ in range(4):
+                    p.stepSimulation()
+
+                frame = self._encode_frame(rgb, action, instruction)
+                with self._lock:
+                    self._frame_jpeg = frame
+                    self._last_action = action
+                    self._step += 1
+                    self._last_error = ""
+            except Exception as exc:  # noqa: BLE001
+                with self._lock:
+                    self._last_error = str(exc)
+                # Avoid hot looping if inference fails
+                time.sleep(0.5)
+                continue
+
+            elapsed = time.time() - t0
+            if elapsed < dt:
+                time.sleep(dt - elapsed)
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        try:
+            p.disconnect(self.cid)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def app(self) -> FastAPI:
+        app = FastAPI(title="OpenVLA Simulation Web Visualizer")
+
+        @app.on_event("startup")
+        def _startup() -> None:
+            self.start()
+
+        @app.on_event("shutdown")
+        def _shutdown() -> None:
+            self.stop()
+
+        @app.get("/", response_class=HTMLResponse)
+        def index() -> str:
+            return """<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenVLA Simulation Visualizer</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 20px; background: #111; color: #eee; }
+      .row { display: flex; gap: 16px; align-items: flex-start; }
+      .card { background: #1b1b1b; padding: 12px; border-radius: 10px; border: 1px solid #333; }
+      input { width: 360px; padding: 8px; border-radius: 6px; border: 1px solid #666; background: #222; color: #fff; }
+      button { margin-left: 8px; padding: 8px 12px; border-radius: 6px; border: 1px solid #666; background: #2f2f2f; color: #fff; cursor: pointer; }
+      #frame { width: 768px; max-width: 90vw; border-radius: 8px; border: 1px solid #333; }
+      pre { white-space: pre-wrap; word-break: break-word; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <h2>OpenVLA 仿真可视化</h2>
+    <div class="card" style="margin-bottom: 12px;">
+      <input id="instruction" value="pick up the red cube" />
+      <button onclick="setInstruction()">更新指令</button>
+    </div>
+    <div class="row">
+      <div class="card">
+        <img id="frame" src="/frame.jpg" />
+      </div>
+      <div class="card" style="min-width: 320px;">
+        <h3 style="margin-top:0;">状态</h3>
+        <pre id="state"></pre>
+      </div>
+    </div>
+    <script>
+      async function setInstruction() {
+        const instruction = document.getElementById('instruction').value;
+        await fetch('/instruction', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instruction }),
+        });
+      }
+      async function refresh() {
+        document.getElementById('frame').src = '/frame.jpg?t=' + Date.now();
+        const r = await fetch('/state');
+        const j = await r.json();
+        document.getElementById('state').textContent = JSON.stringify(j, null, 2);
+      }
+      setInterval(refresh, 300);
+      refresh();
+    </script>
+  </body>
+</html>"""
+
+        @app.get("/frame.jpg")
+        def frame() -> Response:
+            with self._lock:
+                frame = self._frame_jpeg
+            if not frame:
+                black = np.zeros((self.cfg.height, self.cfg.width, 3), dtype=np.uint8)
+                buf = io.BytesIO()
+                Image.fromarray(black).save(buf, format="JPEG", quality=80)
+                frame = buf.getvalue()
+            return Response(content=frame, media_type="image/jpeg")
+
+        @app.get("/state")
+        def state() -> JSONResponse:
+            with self._lock:
+                payload = {
+                    "step": self._step,
+                    "instruction": self._instruction,
+                    "action": self._last_action.tolist(),
+                    "error": self._last_error,
+                    "device": str(self.device),
+                    "unnorm_key": self.cfg.unnorm_key,
+                }
+            return JSONResponse(payload)
+
+        @app.post("/instruction")
+        def update_instruction(body: InstructionBody) -> JSONResponse:
+            with self._lock:
+                self._instruction = body.instruction.strip()
+            return JSONResponse({"ok": True, "instruction": self._instruction})
+
+        return app
+
+
+def parse_args() -> SimConfig:
+    parser = argparse.ArgumentParser(description="OpenVLA PyBullet simulation web visualizer")
+    parser.add_argument("--openvla_path", type=str, required=True, help="HF path or local model directory")
+    parser.add_argument("--unnorm_key", type=str, default="bridge_orig")
+    parser.add_argument("--attn_implementation", type=str, default="flash_attention_2")
+    parser.add_argument("--hz", type=float, default=2.0, help="Inference+control loop frequency")
+    parser.add_argument("--width", type=int, default=768)
+    parser.add_argument("--height", type=int, default=432)
+    parser.add_argument("--pos_scale", type=float, default=0.04)
+    parser.add_argument("--rot_scale", type=float, default=0.25)
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8010)
+    args = parser.parse_args()
+    return SimConfig(
+        openvla_path=args.openvla_path,
+        unnorm_key=args.unnorm_key,
+        attn_implementation=args.attn_implementation,
+        hz=args.hz,
+        width=args.width,
+        height=args.height,
+        pos_scale=args.pos_scale,
+        rot_scale=args.rot_scale,
+        host=args.host,
+        port=args.port,
+    )
+
+
+def main() -> None:
+    cfg = parse_args()
+    server = OpenVLASimServer(cfg)
+    app = server.app()
+    uvicorn.run(app, host=cfg.host, port=cfg.port)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
一、变更背景
本次提交主要解决两个实际问题：

在 Ubuntu 20.04 + A5000 环境中，基于官方仓库进行 OpenVLA 复现时，缺少一份可直接执行、可排障的中文流程文档。
在仿真联调阶段，需要一个可快速验证模型推理链路和可视化状态的脚本集合，帮助确认“模型加载 → 动作生成 → 环境执行 → 状态回传”全链路是否打通。
本 PR 在不改变主训练框架的前提下，补充了文档与脚本，方便在本地完成 LIBERO 任务套件复现与仿真调试。

二、主要改动内容
1) 新增/更新复现文档（中文）
新增并整理了完整的命令清单与流程说明，包括：
环境变量约定
OpenVLA 依赖安装
LIBERO 依赖与配置
官方 checkpoint 下载与完整性检查
LIBERO-Spatial / Object / Goal / 10 四套任务评测命令
常见报错与排查建议（网络、代理、下载中断、端口占用、依赖版本）
目标是实现“从零到跑通”的一键式复现路径，降低部署和汇报成本。

2) 仿真可视化脚本补充
补充了 MuJoCo/OpenVLA 可视化调试脚本，用于在线查看：
当前指令
模型动作输出
环境动作与奖励
图像帧更新状态
仿真阶段信息（用于快速定位黑屏、静帧、动作不变化等问题）
3) 部署脚本健壮性增强
对 vla-scripts/deploy.py 做了兼容性增强：
当本地模型目录缺失某些统计文件时，不直接崩溃退出，改为更可诊断的处理方式（便于本地调试和离线部署）。
4) 忽略本地运行产物
更新 .gitignore，避免将本地评测日志/rollout 等运行产物误提交到仓库，保持提交干净。
三、复现范围与对齐方式
本 PR 复现流程以 OpenVLA 官方 README 的 LIBERO 评测说明为基准，重点对齐以下要素：

任务套件：libero_spatial / libero_object / libero_goal / libero_10
checkpoint：官方发布的对应 fine-tuned 模型
评测入口：experiments/robot/libero/run_libero_eval.py
关键参数：--center_crop True（与官方建议一致）
四、已验证项（本地）
在本地环境中已完成以下验证：

OpenVLA 模型可本地加载并执行推理。
LIBERO 评测脚本可启动并进入 episode 循环。
仿真可视化页面可正常刷新状态并展示动作/奖励变化。
checkpoint 下载支持断点续传，且可通过分片与 index 文件进行完整性检查。
五、注意事项
大模型下载对网络链路较敏感，若代理不稳定可能出现 SSL EOF 或下载中断；文档中已给出重试与恢复方案。
TOKENIZERS_PARALLELISM、TensorFlow oneDNN、robosuite 宏文件等常见提示多数为告警，不影响主流程，可按需静默。
最终成功率应以完整评测回合数统计为准；单个 episode 成败不代表整体结果。
六、对仓库的影响评估
改动集中在文档、仿真调试脚本与部署健壮性，属于增量增强。
不改变主模型结构和训练逻辑。
对现有用户影响较小，主要提升可复现性、可观测性和本地调试效率。
七、后续建议
将中文复现文档进一步整理为 docs/ 下的标准化指南（含 FAQ）。
增加一个最小 smoke test 脚本（例如每任务 1 trial），用于 CI 或快速健康检查。
在 README 中补充“网络不稳定场景下 checkpoint 下载最佳实践”